### PR TITLE
Optimize generated routes for AWS

### DIFF
--- a/packages/tf-next/src/utils/routes.ts
+++ b/packages/tf-next/src/utils/routes.ts
@@ -1,0 +1,22 @@
+import { Route } from '@vercel/routing-utils';
+
+/**
+ * Given an array of routes we filter routes out that start with
+ * - `prefix`
+ * - `/prefix`
+ * - `^prefix`
+ * - `^/prefix`
+ */
+export function removeRoutesByPrefix(routes: Route[], prefix: string) {
+  // https://stackoverflow.com/a/35478115/831465
+  const escapedPrefix = prefix.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+  const matcher = new RegExp(`^\\^?\\/?\\/${escapedPrefix}`);
+
+  return routes.filter(({ src }) => {
+    if (src && src.match(matcher)) {
+      return false;
+    }
+
+    return true;
+  });
+}


### PR DESCRIPTION
Since the CloudFront module handles all routes that have `_next/static/*` prefix we don't need them to be passed to the proxy module.