### PR TITLE
feat: Expose proxy hosted zone id

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ You can create a `.terraformignore` in the root of your project and add the foll
 | Name | Description |
 |------|-------------|
 | cloudfront\_domain\_name | The domain of the main CloudFront distribution. |
+| cloudfront\_hosted\_zone\_id | The zone id of the main CloudFront distribution. |
 | static\_upload\_bucket\_id | n/a |
 
 <!--- END_TF_DOCS --->

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,3 +6,8 @@ output "cloudfront_domain_name" {
   description = "The domain of the main CloudFront distribution."
   value       = module.proxy.cloudfront_domain_name
 }
+
+output "cloudfront_hosted_zone_id" {
+  description = "The zone id of the main CloudFront distribution."
+  value       = module.proxy.cloudfront_hosted_zone_id
+}


### PR DESCRIPTION
Thanks for the project, and your time spent on it!

These small changes aim to allow more complicated aliasing than currently possible with just the name exposed. Having both the domain name and hosted zone id will allow us to punch it into the alias on our own controlled `aws_route53_record` resource directly for a more custom approach to custom domains - as it needs both these values.

The main reason for this is that we currently have different providers in different regions for our infrastructure and managing dns/route53, which as the providers differ means we can't use the currently available approach to custom domains.