### PR TITLE
Upgrade to API Gateway Payload 2.0

### DIFF
--- a/examples/complete/package.json
+++ b/examples/complete/package.json
@@ -14,7 +14,7 @@
     "react-dom": "latest"
   },
   "devDependencies": {
-    "tf-next": "^0.2.0"
+    "tf-next": "latest"
   },
   "license": "MIT"
 }

--- a/examples/custom-domain/package.json
+++ b/examples/custom-domain/package.json
@@ -14,7 +14,7 @@
     "react-dom": "latest"
   },
   "devDependencies": {
-    "tf-next": "^0.2.0"
+    "tf-next": "latest"
   },
   "license": "MIT"
 }

--- a/examples/static/package.json
+++ b/examples/static/package.json
@@ -14,7 +14,7 @@
     "react-dom": "latest"
   },
   "devDependencies": {
-    "tf-next": "^0.2.0"
+    "tf-next": "latest"
   },
   "license": "MIT"
 }

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ locals {
   integration_values = flatten([
     for integration_key, integration in local.lambdas : {
       lambda_arn             = aws_lambda_function.this[integration_key].arn
-      payload_format_version = "1.0"
+      payload_format_version = "2.0"
       timeout_milliseconds   = var.lambda_timeout * 1000
     }
   ])

--- a/packages/node-bridge/src/bridge.ts
+++ b/packages/node-bridge/src/bridge.ts
@@ -11,7 +11,6 @@ import {
   OutgoingHttpHeaders,
   request,
 } from 'http';
-import { URLSearchParams } from 'url';
 
 export interface NowProxyRequest {
   method: string;
@@ -58,9 +57,9 @@ function normalizeAPIGatewayProxyEvent(
     requestContext: {
       http: { method },
     },
+    rawQueryString,
     headers = {},
     body,
-    queryStringParameters,
     pathParameters = {},
     cookies,
   } = event;
@@ -73,8 +72,9 @@ function normalizeAPIGatewayProxyEvent(
   // API Gateway cuts the query string from the path
   // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
   // TODO: Move to Vercel trusted params in future
-  const params = new URLSearchParams(queryStringParameters).toString();
-  const parameterizedPath = params ? `${trimmedPath}?${params}` : trimmedPath;
+  const parameterizedPath = rawQueryString
+    ? `${trimmedPath}?${rawQueryString}`
+    : trimmedPath;
 
   // API Gateway 2.0 payload splits cookie header from the rest,
   // so we need to readd them

--- a/packages/proxy/src/__test__/proxy.test.ts
+++ b/packages/proxy/src/__test__/proxy.test.ts
@@ -124,5 +124,47 @@ describe('Proxy', () => {
         })
       );
     });
+
+    test('/unknown-route-with-tailing-slash/: Redirect tailing slash of unknown route', () => {
+      const route = proxy.route('/unknown-route-with-tailing-slash/');
+      expect(route).toEqual(
+        expect.objectContaining({
+          found: true,
+          dest: '/unknown-route-with-tailing-slash/',
+          status: 308,
+          headers: {
+            Location: '/unknown-route-with-tailing-slash',
+          },
+        })
+      );
+    });
+  });
+
+  describe('Proxy::Routing 004', () => {
+    let proxy: Proxy;
+
+    beforeAll(() => {
+      // Initialize proxy
+      const config = require('./res/config-004.json') as ProxyConfig;
+      proxy = new Proxy(
+        config.routes,
+        config.lambdaRoutes,
+        config.staticRoutes
+      );
+    });
+
+    test('/unknown-route-with-tailing-slash/: Redirect tailing slash of unknown route', () => {
+      const route = proxy.route('/unknown-route-with-tailing-slash/');
+      expect(route).toEqual(
+        expect.objectContaining({
+          found: true,
+          dest: '/unknown-route-with-tailing-slash/',
+          status: 308,
+          headers: {
+            Location: '/unknown-route-with-tailing-slash',
+          },
+        })
+      );
+    });
   });
 });

--- a/packages/proxy/src/__test__/res/config-004.json
+++ b/packages/proxy/src/__test__/res/config-004.json
@@ -1,0 +1,102 @@
+{
+  "lambdas": {
+    "__NEXT_PAGE_LAMBDA_0": {
+      "handler": "now__launcher.launcher",
+      "runtime": "nodejs12.x",
+      "filename": "lambdas/__NEXT_PAGE_LAMBDA_0.zip",
+      "route": "/__NEXT_PAGE_LAMBDA_0"
+    }
+  },
+  "staticRoutes": [
+    "/404",
+    "/hello"
+  ],
+  "routes": [
+    {
+      "src": "^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$",
+      "headers": {
+        "Location": "/$1"
+      },
+      "status": 308,
+      "continue": true
+    },
+    {
+      "src": "^\\/redir1$",
+      "headers": {
+        "Location": "/redir2"
+      },
+      "status": 308
+    },
+    {
+      "src": "^\\/redir2$",
+      "headers": {
+        "Location": "/hello"
+      },
+      "status": 307
+    },
+    {
+      "src": "^\\/redir(?:\\/([^\\/]+?))$",
+      "headers": {
+        "Location": "/$1"
+      },
+      "status": 307
+    },
+    {
+      "src": "/404",
+      "status": 404,
+      "continue": true
+    },
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "^/param/?$",
+      "dest": "/__NEXT_PAGE_LAMBDA_0",
+      "headers": {
+        "x-nextjs-page": "/param"
+      },
+      "check": true
+    },
+    {
+      "handle": "resource"
+    },
+    {
+      "src": "/.*",
+      "status": 404
+    },
+    {
+      "handle": "miss"
+    },
+    {
+      "handle": "rewrite"
+    },
+    {
+      "src": "^/_next/data/NohaCTYF291LU27JmlG_U/param.json$",
+      "dest": "/param",
+      "check": true
+    },
+    {
+      "src": "^/param/?$",
+      "dest": "/__NEXT_PAGE_LAMBDA_0",
+      "headers": {
+        "x-nextjs-page": "/param"
+      },
+      "check": true
+    },
+    {
+      "handle": "hit"
+    },
+    {
+      "handle": "error"
+    },
+    {
+      "src": "/.*",
+      "dest": "/404",
+      "status": 404
+    }
+  ],
+  "buildId": "NohaCTYF291LU27JmlG_U",
+  "prerenders": {},
+  "staticFilesArchive": "static-website-files.zip",
+  "version": 1
+}

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -126,6 +126,11 @@ export class Proxy {
         continue;
       }
 
+      // Skip resource phase entirely because we don't support it
+      if (phase === 'resource') {
+        continue;
+      }
+
       // Special case to allow redirect to kick in when a continue route was touched before
       if (phase === 'error' && isContinue) {
         break;

--- a/packages/tf-next/package.json
+++ b/packages/tf-next/package.json
@@ -19,7 +19,7 @@
     "postpack": "rm ./LICENSE"
   },
   "dependencies": {
-    "@dealmore/next-tf": "2.7.3",
+    "@dealmore/next-tf": "2.7.8",
     "@vercel/build-utils": "^2.6.0",
     "@vercel/frameworks": "^0.0.15",
     "@vercel/routing-utils": "^1.9.1",

--- a/test/fixtures/02-api/next.config.js
+++ b/test/fixtures/02-api/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  generateBuildId() {
+    return 'testing-build-id';
+  },
+};

--- a/test/fixtures/02-api/package.json
+++ b/test/fixtures/02-api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fixture-02",
+  "version": "0.0.0",
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "tf-next": "*"
+  }
+}

--- a/test/fixtures/02-api/pages/api/index.js
+++ b/test/fixtures/02-api/pages/api/index.js
@@ -1,0 +1,5 @@
+export default function handler(req, res) {
+  res.statusCode = 200;
+  res.setHeader('Set-Cookie', ['cookie-1', 'cookie-2']);
+  res.end(JSON.stringify({ foo: 'bar' }));
+}

--- a/test/fixtures/02-api/probes.json
+++ b/test/fixtures/02-api/probes.json
@@ -1,0 +1,11 @@
+{
+  "probes": [
+    {
+      "path": "/api",
+      "status": 200,
+      "responseHeaders": {
+        "Set-Cookie": "cookie-1, cookie-2"
+      }
+    }
+  ]
+}

--- a/test/lib/generateAppModel.ts
+++ b/test/lib/generateAppModel.ts
@@ -93,14 +93,12 @@ export async function generateSAM({ lambdas, cwd }: Props): Promise<SAM> {
         Timeout: 29, // Max timeout from API Gateway
         Events: {
           Api: {
-            Type: 'Api', // TODO: Change to HttpApi (Make sure AWS SAM has min required version)
-            // https://github.com/aws/aws-sam-cli/pull/1942
-            // https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#httpapi
+            Type: 'HttpApi',
             Properties: {
               Path: `${lambda.route}/{proxy+}`,
               Method: 'any',
               TimeoutInMillis: 29000, // Max timeout
-              PayloadFormatVersion: '1.0',
+              PayloadFormatVersion: '2.0',
             },
           },
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,6 +370,11 @@
   resolved "https://registry.yarnpkg.com/@dealmore/next-tf/-/next-tf-2.7.3.tgz#e2ac44f7582819bb531a17190206f0f63f4b3338"
   integrity sha512-y6wQCjxonNeggWZwvK51z/4Cl/3ka5ySAenUo67wM16PrWc92pFEiYaSiObOO/mvVlBJHqCtROEdcoyRab64wg==
 
+"@dealmore/next-tf@2.7.8":
+  version "2.7.8"
+  resolved "https://registry.yarnpkg.com/@dealmore/next-tf/-/next-tf-2.7.8.tgz#7af5ab34857990736acf44bcce64bdc676786164"
+  integrity sha512-Ck05kxO6JaKt8CYzdemC1nvENTF1fpnLmYiBH16+AHF8oD66Q1Dz1n4SvkHVVUD39F6EKtA/htcc1PZQxphfcA==
+
 "@hapi/accept@5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.1.tgz#068553e867f0f63225a506ed74e899441af53e10"
@@ -6646,6 +6651,21 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+tf-next@latest:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tf-next/-/tf-next-0.3.0.tgz#719125ffdd6a326965def619889bf7f78791d793"
+  integrity sha512-0xM19WDqunIEFaXYV3tTMrh5STaaL6LgDGydXROR98slzp283UR9o2Dagfx8tX56oC2xhO67WmsNZrZ9298j9Q==
+  dependencies:
+    "@dealmore/next-tf" "2.7.3"
+    "@vercel/build-utils" "^2.6.0"
+    "@vercel/frameworks" "^0.0.15"
+    "@vercel/routing-utils" "^1.9.1"
+    archiver "^5.1.0"
+    fs-extra "^9.0.1"
+    glob "^7.1.6"
+    tmp "^0.2.1"
+    yargs "^15.3.1"
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## ToDo

- [x] Understand the change between `path` and `rawPath` (https://twitter.com/hichaelmart/status/1238547529563856897)   
  - Can we extract the real path from `pathParameters`?
- [x] Add unit tests for proxy routes, e.g. `ANY /LAMBDA_001/{proxy+}`
- [x] Add e2e test for things like set multiple cookies and multi value headers
- [x] This will be a breaking change for `tf-next` and the terraform module version, could make sense to implement #5 for this

Fixes #29 

## Payload Examples

### 1.0
```json
{
  "version": "1.0",
  "resource": "/__NEXT_PAGE_LAMBDA_0/{proxy+}",
  "path": "/__NEXT_PAGE_LAMBDA_0/test",
  "httpMethod": "GET",
  "headers": {
    "Content-Length": "0",
    "Host": "7t3jzzs4vk.execute-api.eu-central-1.amazonaws.com",
    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36",
    "X-Amzn-Trace-Id": "Root=1-5fff599f-6fca6ee66e37fe5e518eb45b",
    "X-Forwarded-For": "84.142.29.66",
    "X-Forwarded-Port": "443",
    "X-Forwarded-Proto": "https",
    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
    "accept-encoding": "gzip, deflate, br",
    "accept-language": "en-US,en;q=0.9,de-DE;q=0.8,de;q=0.7",
    "cache-control": "max-age=0",
    "sec-ch-ua": "\"Google Chrome\";v=\"87\", \" Not;A Brand\";v=\"99\", \"Chromium\";v=\"87\"",
    "sec-ch-ua-mobile": "?0",
    "sec-fetch-dest": "document",
    "sec-fetch-mode": "navigate",
    "sec-fetch-site": "none",
    "sec-fetch-user": "?1",
    "upgrade-insecure-requests": "1"
  },
  "multiValueHeaders": {
    "Content-Length": [
      "0"
    ],
    "Host": [
      "7t3jzzs4vk.execute-api.eu-central-1.amazonaws.com"
    ],
    "User-Agent": [
      "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36"
    ],
    "X-Amzn-Trace-Id": [
      "Root=1-5fff599f-6fca6ee66e37fe5e518eb45b"
    ],
    "X-Forwarded-For": [
      "84.142.29.66"
    ],
    "X-Forwarded-Port": [
      "443"
    ],
    "X-Forwarded-Proto": [
      "https"
    ],
    "accept": [
      "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
    ],
    "accept-encoding": [
      "gzip, deflate, br"
    ],
    "accept-language": [
      "en-US,en;q=0.9,de-DE;q=0.8,de;q=0.7"
    ],
    "cache-control": [
      "max-age=0"
    ],
    "sec-ch-ua": [
      "\"Google Chrome\";v=\"87\", \" Not;A Brand\";v=\"99\", \"Chromium\";v=\"87\""
    ],
    "sec-ch-ua-mobile": [
      "?0"
    ],
    "sec-fetch-dest": [
      "document"
    ],
    "sec-fetch-mode": [
      "navigate"
    ],
    "sec-fetch-site": [
      "none"
    ],
    "sec-fetch-user": [
      "?1"
    ],
    "upgrade-insecure-requests": [
      "1"
    ]
  },
  "queryStringParameters": null,
  "multiValueQueryStringParameters": null,
  "requestContext": {
    "accountId": "161692622609",
    "apiId": "7t3jzzs4vk",
    "domainName": "7t3jzzs4vk.execute-api.eu-central-1.amazonaws.com",
    "domainPrefix": "7t3jzzs4vk",
    "extendedRequestId": "ZGrw7jKGFiAEJig=",
    "httpMethod": "GET",
    "identity": {
      "accessKey": null,
      "accountId": null,
      "caller": null,
      "cognitoAmr": null,
      "cognitoAuthenticationProvider": null,
      "cognitoAuthenticationType": null,
      "cognitoIdentityId": null,
      "cognitoIdentityPoolId": null,
      "principalOrgId": null,
      "sourceIp": "84.142.29.66",
      "user": null,
      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36",
      "userArn": null
    },
    "path": "/__NEXT_PAGE_LAMBDA_0/test",
    "protocol": "HTTP/1.1",
    "requestId": "ZGrw7jKGFiAEJig=",
    "requestTime": "13/Jan/2021:20:35:43 +0000",
    "requestTimeEpoch": 1610570143429,
    "resourceId": "ANY /__NEXT_PAGE_LAMBDA_0/{proxy+}",
    "resourcePath": "/__NEXT_PAGE_LAMBDA_0/{proxy+}",
    "stage": "$default"
  },
  "pathParameters": {
    "proxy": "test"
  },
  "stageVariables": null,
  "body": null,
  "isBase64Encoded": false
}
```

### 2.0
```json
{
  "version": "2.0",
  "routeKey": "ANY /__NEXT_PAGE_LAMBDA_0/{proxy+}",
  "rawPath": "/__NEXT_PAGE_LAMBDA_0/test",
  "rawQueryString": "",
  "headers": {
    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
    "accept-encoding": "gzip, deflate, br",
    "accept-language": "en-US,en;q=0.9,de-DE;q=0.8,de;q=0.7",
    "content-length": "0",
    "host": "7t3jzzs4vk.execute-api.eu-central-1.amazonaws.com",
    "sec-ch-ua": "\"Google Chrome\";v=\"87\", \" Not;A Brand\";v=\"99\", \"Chromium\";v=\"87\"",
    "sec-ch-ua-mobile": "?0",
    "sec-fetch-dest": "document",
    "sec-fetch-mode": "navigate",
    "sec-fetch-site": "none",
    "sec-fetch-user": "?1",
    "upgrade-insecure-requests": "1",
    "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36",
    "x-amzn-trace-id": "Root=1-5fff5702-662056cc228c38b00e18933d",
    "x-forwarded-for": "84.142.29.66",
    "x-forwarded-port": "443",
    "x-forwarded-proto": "https"
  },
  "requestContext": {
    "accountId": "161692622609",
    "apiId": "7t3jzzs4vk",
    "domainName": "7t3jzzs4vk.execute-api.eu-central-1.amazonaws.com",
    "domainPrefix": "7t3jzzs4vk",
    "http": {
      "method": "GET",
      "path": "/__NEXT_PAGE_LAMBDA_0/test",
      "protocol": "HTTP/1.1",
      "sourceIp": "84.142.29.66",
      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36"
    },
    "requestId": "ZGqIegxrliAEMig=",
    "routeKey": "ANY /__NEXT_PAGE_LAMBDA_0/{proxy+}",
    "stage": "$default",
    "time": "13/Jan/2021:20:24:34 +0000",
    "timeEpoch": 1610569474961
  },
  "pathParameters": {
    "proxy": "test"
  },
  "isBase64Encoded": false
}
```