### PR TITLE
CI: Remove extra docker setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ABIAZLJNBT8I3KFOU4NO
       AWS_SECRET_ACCESS_KEY: 4Xt3Rbx4DO21MhK1IHXZXRvVRDuqaQ0Wo5lILA/h
     steps:
-      - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
       - name: Setup Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
As seen in https://github.com/dealmore/apollo-link-lambda/pull/4. We should no longer need the docker setup, since docker comes preinstalled on GitHub Actions machines.