### PR TITLE
feat: 🎸 Add lambda_role_permissions_boundary variable for iam

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ You can create a `.terraformignore` in the root of your project and add the foll
 | lambda\_policy\_json | An additional policy document as JSON to attach to the Lambda Function role | `string` | `null` | no |
 | lambda\_runtime | Lambda Function runtime | `string` | `"nodejs12.x"` | no |
 | lambda\_timeout | The max amount of time a Lambda Function has to return a response in seconds. Should not be more than 30 (Limited by API Gateway). | `number` | `10` | no |
+| lambda\_role\_permissions\_boundary | ARN of IAM policy that scopes aws_iam_role access for the lambda. | `string` | `null` | no |
 | next\_tf\_dir | Relative path to the .next-tf dir. | `string` | `"./.next-tf"` | no |
 
 ## Outputs

--- a/iam.tf
+++ b/iam.tf
@@ -20,6 +20,8 @@ resource "aws_iam_role" "lambda" {
   name        = random_id.function_name[each.key].hex
   description = "Managed by Terraform Next.js"
 
+  permissions_boundary = var.lambda_role_permissions_boundary
+
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,13 @@ variable "lambda_policy_json" {
   default     = null
 }
 
+variable "lambda_role_permissions_boundary" {
+  type = string
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
+  description = "ARN of IAM policy that scopes aws_iam_role access for the lambda"
+  default     = null
+}
+
 #########################
 # Cloudfront Distribution
 #########################


### PR DESCRIPTION
Once again, thanks for the work on the project! Just some more tweaks to build out some of the options for the module to allow it to be more flexible, as I also try to make it accommodate our workflows and what we need for it.

This allows a [permission boundary](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html)
to be optionally set if needed for the `aws_iam_role` used for lambdas.