### PR TITLE
fix: 🐛 Pass permissions boundary to edge proxy lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -143,6 +143,7 @@ module "proxy" {
   cloudfront_minimum_protocol_version = var.cloudfront_minimum_protocol_version
   debug_use_local_packages            = var.debug_use_local_packages
   tags                                = var.tags
+  lambda_role_permissions_boundary    = var.lambda_role_permissions_boundary
 
   providers = {
     aws = aws.global_region

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -43,6 +43,7 @@ module "edge_proxy" {
   description   = "Managed by Terraform-next.js"
   handler       = "handler.handler"
   runtime       = var.lambda_default_runtime
+  role_permissions_boundary = var.lambda_role_permissions_boundary
 
   create_package         = false
   local_existing_package = module.proxy_package.abs_path

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -65,3 +65,8 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "lambda_role_permissions_boundary" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
Hey again 👋 

This fixes something I missed when adding the original permission boundary PR, which only added it through to the lambdas, I missed the proxy lambda. We need to do this otherwise without this the boundary isn't set properly, as the proxy lambda leaks outside of it.