### PR TITLE
fix: 🐛 Add permission boundary to static deploy lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ module "statics_deploy" {
   cloudfront_id            = module.proxy.cloudfront_id
   cloudfront_arn           = module.proxy.cloudfront_arn
   tags                     = var.tags
+  lambda_role_permissions_boundary = var.lambda_role_permissions_boundary
 }
 
 # Lambda

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -168,6 +168,7 @@ module "deploy_trigger" {
   timeout       = 60
   publish       = true
   tags          = var.tags
+  role_permissions_boundary = var.lambda_role_permissions_boundary
 
   create_package         = false
   local_existing_package = module.lambda_content.abs_path

--- a/modules/statics-deploy/variables.tf
+++ b/modules/statics-deploy/variables.tf
@@ -30,3 +30,8 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "lambda_role_permissions_boundary" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
This is the last place that this should be needed. Sorry for staggering this boundary change over multiple PRs, and thanks for being so responsive and all your work on this module.