### PR TITLE
Request cookie header should be semi-colon delimitated

### DIFF
--- a/packages/node-bridge/src/bridge.ts
+++ b/packages/node-bridge/src/bridge.ts
@@ -79,7 +79,7 @@ function normalizeAPIGatewayProxyEvent(
   // API Gateway 2.0 payload splits cookie header from the rest,
   // so we need to readd them
   if (cookies) {
-    headers['cookie'] = cookies.join(', ');
+    headers['cookie'] = cookies.join('; ');
   }
 
   if (body) {

--- a/packages/node-bridge/test/bridge.test.js
+++ b/packages/node-bridge/test/bridge.test.js
@@ -112,7 +112,7 @@ test('[APIGatewayProxyEvent] cookie handling', async () => {
   const body = JSON.parse(Buffer.from(result.body, 'base64').toString());
   expect(body.method).toBe('POST');
   expect(body.path).toBe('/');
-  expect(body.headers.cookie).toBe('cookie-1, cookie-2, cookie-3');
+  expect(body.headers.cookie).toBe('cookie-1; cookie-2; cookie-3');
 
   server.close();
 });

--- a/packages/node-bridge/test/bridge.test.js
+++ b/packages/node-bridge/test/bridge.test.js
@@ -91,7 +91,7 @@ test('[APIGatewayProxyEvent] cookie handling', async () => {
 
   const result = await bridge.launcher(
     {
-      cookies: ['cookie-1, cookie-2', 'cookie-3'],
+      cookies: ['cookie-1; cookie-2', 'cookie-3'],
       rawPath: '/__NEXT_PAGE_LAMBDA_0/',
       requestContext: {
         http: {


### PR DESCRIPTION
Thanks for fixing #29!

Just one little bug left, cookies in the request header should be separated by semi-colons instead of commas.
