### PR TITLE
Fix zone IDs matched against zone names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -240,7 +240,7 @@ module "proxy" {
 data "aws_route53_zone" "alias_domains" {
   count = var.create_domain_name_records ? length(var.domain_zone_names) : 0
 
-  name = var.domain_zone_names[count.index]
+  zone_id = var.domain_zone_names[count.index]
 }
 
 resource "aws_route53_record" "alias_domains" {


### PR DESCRIPTION
It's a bit confusing, but as per example tf file,
`domain_zone_names` actually contains zone IDs currently:
https://github.com/dealmore/terraform-aws-next-js/blob/7adffcf2e632a25bba14d4d394835da97c201f69/examples/custom-domain/main.tf#L55

Fixes https://github.com/dealmore/terraform-aws-next-js/issues/60