### PR TITLE
custom-domain: Remove illegal characters from deployment_name

### DIFF
--- a/examples/custom-domain/main.tf
+++ b/examples/custom-domain/main.tf
@@ -52,7 +52,7 @@ module "cloudfront_cert" {
 module "tf_next" {
   source = "dealmore/next-js/aws"
 
-  deployment_name = "Custom Domain Example ${local.custom_domain}"
+  deployment_name = "custom-domain-example"
 
   # You can also attach multiple domains here since it accepts an array
   # Keep in mind that `domain_names` & `domain_zone_names` should always


### PR DESCRIPTION
A role name is generated from `deployment_name` here, which cannot have spaces.
An AWS Lambda function name is also generated, which cannot have dots.