### PR TITLE
Fix compatibility with nodejs 14.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.27.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
The runtime and memory_size variables are strings and numbers so the lookup function fails since it requires a map.

The error is:

```
Error: expected runtime to be one of [nodejs nodejs4.3 nodejs6.10 nodejs8.10 nodejs10.x nodejs12.x java8 java8.al2 java11 python2.7 python3.6 python3.7 python3.8 dotnetcore1.0 dotnetcore2.0 dotnetcore2.1 dotnetcore3.1 nodejs4.3-edge go1.x ruby2.5 ruby2.7 provided provided.al2], got nodejs14.x
```