### PR TITLE
chore: bump versions to implement fixes in upstream modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ locals {
 
 module "api_gateway" {
   source  = "terraform-aws-modules/apigateway-v2/aws"
-  version = "0.5.0"
+  version = "0.11.0"
 
   name          = var.deployment_name
   description   = "Managed by Terraform-next.js"
@@ -140,7 +140,7 @@ module "next_image" {
   count = var.create_image_optimization ? 1 : 0
 
   source  = "dealmore/next-js-image-optimization/aws"
-  version = "2.0.0"
+  version = "2.0.1"
 
   cloudfront_create_distribution = false
   next_image_version             = var.image_optimization_version


### PR DESCRIPTION
This PR bumps the modules to use the fixes provided in the following PRs:

https://github.com/dealmore/terraform-aws-next-js-image-optimization/pull/16
https://github.com/terraform-aws-modules/terraform-aws-apigateway-v2/pull/24

Note: I've preemptively picked a version number of 2.0.1 for the next version of your `next-js-image-optimisation` module (providing you are happy to merge my patch) - but if that doesn't work let me know and I can amend here.