### PR TITLE
Add flag to use AWSCLI or Bash for static upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules
 # Build output
 .next
 .next-tf
+
+# Temp files
+*.swp*

--- a/iam.tf
+++ b/iam.tf
@@ -24,7 +24,7 @@ resource "aws_iam_role" "lambda" {
 
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 
-  tags        = var.tags
+  tags = var.tags
 }
 
 #############################
@@ -37,7 +37,7 @@ resource "aws_cloudwatch_log_group" "this" {
   name              = "/aws/lambda/${random_id.function_name[each.key].hex}"
   retention_in_days = 14
 
-  tags              = var.tags
+  tags = var.tags
 }
 
 data "aws_iam_policy_document" "lambda_logging" {

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ module "statics_deploy" {
   cloudfront_arn                   = module.proxy.cloudfront_arn
   tags                             = var.tags
   lambda_role_permissions_boundary = var.lambda_role_permissions_boundary
+  use_awscli_for_static_upload     = var.use_awscli_for_static_upload
 }
 
 # Lambda

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -40,10 +40,10 @@ module "edge_proxy" {
 
   lambda_at_edge = true
 
-  function_name = random_id.function_name.hex
-  description   = "Managed by Terraform-next.js"
-  handler       = "handler.handler"
-  runtime       = var.lambda_default_runtime
+  function_name             = random_id.function_name.hex
+  description               = "Managed by Terraform-next.js"
+  handler                   = "handler.handler"
+  runtime                   = var.lambda_default_runtime
   role_permissions_boundary = var.lambda_role_permissions_boundary
 
   create_package         = false
@@ -51,7 +51,7 @@ module "edge_proxy" {
 
   cloudwatch_logs_retention_in_days = 30
 
-  tags          = var.tags
+  tags = var.tags
 }
 
 ############
@@ -59,13 +59,13 @@ module "edge_proxy" {
 ############
 
 resource "aws_cloudfront_distribution" "distribution" {
-  enabled         = true
-  is_ipv6_enabled = true
-  comment         = "${var.deployment_name} - Main"
-  price_class     = var.cloudfront_price_class
-  aliases         = var.cloudfront_alias_domains
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${var.deployment_name} - Main"
+  price_class         = var.cloudfront_price_class
+  aliases             = var.cloudfront_alias_domains
   default_root_object = "index"
-  tags            = var.tags
+  tags                = var.tags
 
   # Static deployment S3 bucket
   origin {

--- a/modules/statics-deploy/variables.tf
+++ b/modules/statics-deploy/variables.tf
@@ -35,3 +35,8 @@ variable "lambda_role_permissions_boundary" {
   type    = string
   default = null
 }
+
+variable "use_awscli_for_static_upload" {
+  type    = bool
+  default = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "expire_static_assets" {
   default     = 30
 }
 
+variable "use_awscli_for_static_upload" {
+  description = "Use AWS CLI when uploading static resources to S3 instead of default Bash script. Some cases may fail with 403 Forbidden when using the Bash script."
+  type        = bool
+  default     = false
+}
+
 ###################
 # Lambdas (Next.js)
 ###################


### PR DESCRIPTION
Some cases could result in a 403 Forbidden error when the included Bash
script is used to upload the static files archive to S3. This can be
avoided by using the AWS CLI on the same file system with the same set of
environment variables.

This commit adds a TF variable of boolean type to use the AWS CLI if set
to true. Users who come across the issue can set this flag (false by
default) to workaround the issue.

This commit also adds a few TF fmt changes.

The usage of this flag is as follows.

```hcl
module "tf_next" {
  source          = "dealmore/next-js/aws"
  use_awscli_for_static_upload = true
}
```

This PR addresses #40 