### PR TITLE
Allow dependencies to detect the build environment

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -250,6 +250,20 @@ export async function build({
   const nodeVersion = await getNodeVersion(entryPath, undefined, config, meta);
   const spawnOpts = getSpawnOptions(meta, nodeVersion);
 
+  // Add Vercel build environment variables that some dependencies need
+  // to determine a Vercel like build environment
+  spawnOpts.env = {
+    ...spawnOpts.env,
+    NOW_BUILDER: '1',
+    VERCEL: '1',
+    // Next.js changed the default output folder beginning with
+    // 10.0.8-canary.15 from `.next/serverless` to `.next/server`.
+    // This is an opt-out of this behavior until we support it.
+    // https://github.com/dealmore/terraform-aws-next-js/issues/86
+    // https://github.com/vercel/next.js/pull/22731
+    NEXT_PRIVATE_TARGET: 'experimental-serverless-trace',
+  };
+
   const nowJsonPath = await findUp(['now.json', 'vercel.json'], {
     cwd: entryPath,
   });

--- a/packages/runtime/test/integration/index.test.js
+++ b/packages/runtime/test/integration/index.test.js
@@ -468,3 +468,16 @@ it(
   },
   FOUR_MINUTES
 );
+
+it(
+  'Should should run the postinstall script',
+  async () => {
+    const {
+      workPath,
+      buildResult: { output },
+    } = await runBuildLambda(path.join(__dirname, 'postinstall'));
+
+    expect(output['prisma.txt']).toBeDefined();
+  },
+  FOUR_MINUTES
+);

--- a/packages/runtime/test/integration/postinstall/now.json
+++ b/packages/runtime/test/integration/postinstall/now.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "builds": [{ "src": "package.json", "use": "@dealmore/tf-next-runtime" }]
+}

--- a/packages/runtime/test/integration/postinstall/package.json
+++ b/packages/runtime/test/integration/postinstall/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/packages/runtime/test/integration/postinstall/pages/goodbye.js
+++ b/packages/runtime/test/integration/postinstall/pages/goodbye.js
@@ -1,0 +1,3 @@
+const F = () => 'Goodbye World!';
+F.getInitialProps = async () => ({});
+export default F;

--- a/packages/runtime/test/integration/postinstall/pages/index.js
+++ b/packages/runtime/test/integration/postinstall/pages/index.js
@@ -1,0 +1,1 @@
+export default () => 'Hello World!';

--- a/packages/runtime/test/integration/postinstall/postinstall.js
+++ b/packages/runtime/test/integration/postinstall/postinstall.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+// Some packages like Prisma rely on the `NOW_BUILDER` environment variable
+// to determine if the build is running with the Vercel builder
+
+// Prisma: https://github.com/prisma/prisma/blob/1d0045fe60dc1992173f3f5be84b24129f0d45a3/src/packages/cli/scripts/install.js#L10
+if (process.env.INIT_CWD && process.env.NOW_BUILDER) {
+  fs.writeFileSync('public/prisma.txt', '');
+}


### PR DESCRIPTION
Some dependencies (like Blitz.js or Prisma) using the environment variables `NOW_BUILDER` or `VERCEL_BUILDER` to run special configurations for Vercel builds.

Since the builder we use here is also a Vercel like environment we should make sure that these environment variables are set correctly when running the build steps.

Setting the environment variables however has an unintended side-effect, because Next.js changed the output folder for serverless-like environments from `.next/serverless` to `.next/server` ([next#22731](https://github.com/vercel/next.js/pull/22731)), so a version switch is also applied.

Relates #73.
Relates #70.