### PR TITLE
Skip CloudFront invalidation for unchanged files

### DIFF
--- a/packages/deploy-trigger/src/__test__/update-manifest.test.ts
+++ b/packages/deploy-trigger/src/__test__/update-manifest.test.ts
@@ -20,13 +20,16 @@ describe('deploy-trigger', () => {
   let s3: S3;
   let bucket: BucketHandler;
 
-  beforeAll(async () => {
+  beforeAll(() => {
     // Initialize the local S3 client
     s3 = generateS3ClientForTesting();
+  });
+
+  beforeEach(async () => {
     bucket = await createBucket(s3);
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await bucket.destroy();
   });
 
@@ -43,7 +46,7 @@ describe('deploy-trigger', () => {
     ];
     let manifest: Manifest;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       await addFilesToS3Bucket(s3, bucket.bucketName, toBeExpiredFiles);
       manifest = await getOrCreateManifest(
         s3,

--- a/packages/deploy-trigger/src/__test__/utils.ts
+++ b/packages/deploy-trigger/src/__test__/utils.ts
@@ -94,7 +94,7 @@ export async function generateZipBundle(filesNames: string[]) {
   });
 }
 
-export async function addFilesToS3Bucket(
+export function addFilesToS3Bucket(
   s3: S3,
   bucketId: string,
   fileNames: string[]
@@ -102,12 +102,14 @@ export async function addFilesToS3Bucket(
   const promises = [];
 
   for (const fileName of fileNames) {
+    // Fill with random body to create different etags in S3
+    const body = crypto.randomBytes(20).toString('hex');
     promises.push(
       s3
         .putObject({
           Bucket: bucketId,
           Key: fileName,
-          Body: '',
+          Body: body,
         })
         .promise()
     );

--- a/packages/deploy-trigger/src/types.ts
+++ b/packages/deploy-trigger/src/types.ts
@@ -1,13 +1,9 @@
 export type ExpireValue = number | 'never';
 
-interface Build {
-  files: string[];
-  expiredAt?: string;
-}
-
 export interface ManifestFile {
   buildId: string[];
   expiredAt?: string;
+  eTag?: string;
 }
 
 export interface Manifest {
@@ -15,4 +11,9 @@ export interface Manifest {
   currentBuild: string;
   // All files that are currently managed by the manifest
   files: Record<string, ManifestFile>;
+}
+
+export interface FileResult {
+  key: string;
+  eTag: string;
 }


### PR DESCRIPTION
Before creating the invalidations for CloudFront it is now checked for each file if the `eTag` of the S3 object has changed.
If the eTag is unchanged the invalidation is skipped.

Useful for static files (e.g. `robots.txt`, `favicon.ico`) that mostly have the same content between multiple deployments, but have no hashes in their filenames.

Relates #48.