### PR TITLE
feat: 🎸 Allow better control of geo restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ You can create a `.terraformignore` in the root of your project and add the foll
 | cloudfront\_origins | n/a | `list(any)` | `null` | no |
 | cloudfront\_price\_class | Price class for the CloudFront distributions (main & proxy config). One of PriceClass\_All, PriceClass\_200, PriceClass\_100. | `string` | `"PriceClass_100"` | no |
 | cloudfront\_viewer\_certificate\_arn | n/a | `string` | `null` | no |
+| cloudfront\_geo\_restriction | Options to control distribution of content, object with restriction_type and locations. | `object({ restriction_type = string, locations = list(string) })` | `{ restriction_type = "none", locations = [] }` | no |
 | create\_domain\_name\_records | Controls whether Route 53 records for the for the domain\_names should be created. | `bool` | `true` | no |
 | create\_image\_optimization | Controls whether resources for image optimization support should be created or not. | `bool` | `true` | no |
 | debug\_use\_local\_packages | Use locally built packages rather than download them from npm. | `bool` | `false` | no |

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -192,8 +192,12 @@ resource "aws_cloudfront_distribution" "distribution" {
   }
 
   restrictions {
-    geo_restriction {
-      restriction_type = "none"
+    dynamic "geo_restriction" {
+      for_each = list(var.cloudfront_geo_restriction)
+      content {
+        restriction_type = geo_restriction.value["restriction_type"]
+        locations = geo_restriction.value["locations"]
+      }
     }
   }
 

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -76,6 +76,22 @@ variable "cloudfront_cache_policy_id" {
   type = string
 }
 
+variable "cloudfront_geo_restriction" {
+  description = "Options to control distribution of content, object with restriction_type and locations."
+  type = object({
+    restriction_type = string,
+    locations = list(string),
+  })
+  default = {
+    restriction_type = "none"
+    locations = []
+  }
+  validation {
+    condition = contains(["none", "blacklist", "whitelist"], var.cloudfront_geo_restriction.restriction_type)
+    error_message = "The restriction_type must be \"none\", \"blacklist\", or \"whitelist\"."
+  }
+}
+
 ##########
 # Labeling
 ##########

--- a/variables.tf
+++ b/variables.tf
@@ -118,6 +118,22 @@ variable "cloudfront_cache_key_headers" {
   default     = ["Authorization"]
 }
 
+variable "cloudfront_geo_restriction" {
+  description = "Options to control distribution of content, object with restriction_type and locations."
+  type = object({
+    restriction_type = string,
+    locations = list(string),
+  })
+  default = {
+    restriction_type = "none"
+    locations = []
+  }
+  validation {
+    condition = contains(["none", "blacklist", "whitelist"], var.cloudfront_geo_restriction.restriction_type)
+    error_message = "The restriction_type must be \"none\", \"blacklist\", or \"whitelist\"."
+  }
+}
+
 ##########
 # Labeling
 ##########


### PR DESCRIPTION
👋  Hey there, thanks for all the work on the project.

This is a PR to allow better control of geo restriction via `cloudfront_geo_restriction` variable, and also makes sure the variable is valid (checks the restriction_type is one of the allowed values, and that locations is a list of strings). Defaults to `none` still, so shouldn't cause any change until it's set.