### PR TITLE
Fix: Adds proxy provider to proxy-config module

### DIFF
--- a/modules/proxy-config/main.tf
+++ b/modules/proxy-config/main.tf
@@ -9,6 +9,7 @@ locals {
 ########
 
 resource "aws_s3_bucket" "proxy_config" {
+  provider      = aws.global_region
   bucket_prefix = "next-tf-proxy-config"
   acl           = "private"
   force_destroy = true
@@ -28,8 +29,9 @@ data "aws_iam_policy_document" "cf_access" {
 }
 
 resource "aws_s3_bucket_policy" "origin_access" {
-  bucket = aws_s3_bucket.proxy_config.id
-  policy = data.aws_iam_policy_document.cf_access.json
+  provider = aws.global_region
+  bucket   = aws_s3_bucket.proxy_config.id
+  policy   = data.aws_iam_policy_document.cf_access.json
 }
 
 #####################
@@ -37,6 +39,7 @@ resource "aws_s3_bucket_policy" "origin_access" {
 #####################
 
 resource "aws_s3_bucket_object" "proxy_config" {
+  provider      = aws.global_region
   bucket        = aws_s3_bucket.proxy_config.id
   key           = local.proxy_config_key
   content       = var.proxy_config_json

--- a/modules/proxy-config/provider.tf
+++ b/modules/proxy-config/provider.tf
@@ -1,0 +1,7 @@
+# Proxy AWS provider for Lambda@Edge
+# TODO: We only use the proxy provider here for better upgradibility
+# from 0.7.x -> 0.8.x
+# Should be removed with the release of 0.9.x
+provider "aws" {
+  alias = "global_region"
+}

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -23,6 +23,10 @@ module "proxy_config" {
   proxy_config_json      = var.proxy_config_json
   deployment_name        = var.deployment_name
   tags                   = var.tags
+
+  providers = {
+    aws.global_region = aws.global_region
+  }
 }
 
 #############


### PR DESCRIPTION
This is a temporary fix, to keep the current region of an existing S3 bucket.
Will be reverted by #102 in the next release.

Follow up of #101.