### PR TITLE
(fix) - use base argument in build

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -80,7 +80,6 @@ interface BuildParamsMeta {
 
 interface BuildParamsType extends BuildOptions {
   files: Files;
-  base: string;
   entrypoint: string;
   workPath: string;
   meta: BuildParamsMeta;
@@ -217,7 +216,6 @@ function startDevServer(entryPath: string, runtimeEnv: EnvConfig) {
 
 export async function build({
   files,
-  base,
   workPath,
   repoRootPath,
   entrypoint,
@@ -1114,7 +1112,7 @@ export async function build({
         fileList: apiFileList,
         reasons: apiReasons,
       } = await nodeFileTrace(apiPages, {
-        base,
+        base: baseDir,
         processCwd: entryPath,
         cache: nftCache,
       });
@@ -1124,7 +1122,7 @@ export async function build({
       const { fileList, reasons: nonApiReasons } = await nodeFileTrace(
         nonApiPages,
         {
-          base,
+          base: baseDir,
           processCwd: entryPath,
           cache: nftCache,
         }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -80,6 +80,7 @@ interface BuildParamsMeta {
 
 interface BuildParamsType extends BuildOptions {
   files: Files;
+  base: string;
   entrypoint: string;
   workPath: string;
   meta: BuildParamsMeta;
@@ -216,6 +217,7 @@ function startDevServer(entryPath: string, runtimeEnv: EnvConfig) {
 
 export async function build({
   files,
+  base,
   workPath,
   repoRootPath,
   entrypoint,
@@ -1112,7 +1114,7 @@ export async function build({
         fileList: apiFileList,
         reasons: apiReasons,
       } = await nodeFileTrace(apiPages, {
-        base: baseDir,
+        base,
         processCwd: entryPath,
         cache: nftCache,
       });
@@ -1122,7 +1124,7 @@ export async function build({
       const { fileList, reasons: nonApiReasons } = await nodeFileTrace(
         nonApiPages,
         {
-          base: baseDir,
+          base,
           processCwd: entryPath,
           cache: nftCache,
         }

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -170,6 +170,7 @@ async function buildCommand({
   const workspaceRoot = findWorkspaceRoot(cwd);
   const repoRootPath = workspaceRoot ?? cwd;
   const outputDir = path.join(cwd, '.next-tf');
+  const workPath = mode === 'download' ? tmpDir!.name : repoRootPath;
 
   // Ensure that the output dir exists
   fs.ensureDirSync(outputDir);
@@ -179,7 +180,7 @@ async function buildCommand({
   try {
     // Entrypoint is the relative path to the package.json or next.config.js
     // from repoRootPath
-    const entrypoint = workspaceRoot ? path.join(path.relative(workspaceRoot, cwd), 'package.json') : 'package.json';
+    const entrypoint = findEntryPoint(repoRootPath, cwd);
     const lambdas: Lambdas = {};
     const prerenders: Prerenders = {};
     const staticWebsiteFiles: StaticWebsiteFiles = {};
@@ -198,9 +199,10 @@ async function buildCommand({
     });
 
     // Get BuildId
-    // TODO: Should be part of buildResult since it's already there
+    const entryDirectory = path.dirname(entrypoint);
+    const entryPath = path.join(workPath, entryDirectory);
     const buildId = await fs.readFile(
-      path.join(mode === 'download' ? tmpDir!.name : cwd, '.next', 'BUILD_ID'),
+      path.join(entryPath, '.next', 'BUILD_ID'),
       'utf8'
     );
 

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -185,8 +185,8 @@ async function buildCommand({
 
     const buildResult = await build({
       files,
-      workPath: cwd,
-      base: workPath,
+      workPath: mode === 'download' ? tmpDir!.name : cwd,
+      base: mode === 'download' ? tmpDir!.name : repoRootPath,
       entrypoint,
       config: { sharedLambdas: true },
       meta: {

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -187,7 +187,7 @@ async function buildCommand({
 
     const buildResult = await build({
       files,
-      workPath: mode === 'download' ? tmpDir!.name : cwd,
+      workPath,
       entrypoint,
       repoRootPath: workspaceRoot ? workspaceRoot : undefined,
       config: { sharedLambdas: true, installCommand },

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -167,9 +167,9 @@ async function buildCommand({
 
   const workspaceRoot = findWorkspaceRoot(cwd);
   const repoRootPath = workspaceRoot ?? cwd;
-  // TODO: temp to see if my assumption about location of .next-tf in tests is correct
-  const outputDir = path.join(repoRootPath, '.next-tf');
   const workPath = mode === 'download' ? tmpDir!.name : cwd;
+  // TODO: temp to see if my assumption about location of .next-tf in tests is correct
+  const outputDir = path.join(cwd, '.next-tf');
 
   // Ensure that the output dir exists
   fs.ensureDirSync(outputDir);

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -189,7 +189,7 @@ async function buildCommand({
       workPath,
       entrypoint,
       repoRootPath: workspaceRoot ? workspaceRoot : undefined,
-      config: { sharedLambdas: true, installCommand },
+      config: { sharedLambdas: true },
       meta: {
         isDev: false,
         // @ts-ignore

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -145,7 +145,6 @@ interface BuildProps {
   skipDownload?: boolean;
   logLevel?: 'verbose' | 'none';
   deleteBuildCache?: boolean;
-  installCommand?: string;
   cwd: string;
   target?: 'AWS';
 }
@@ -153,7 +152,6 @@ interface BuildProps {
 async function buildCommand({
   skipDownload = false,
   logLevel,
-  installCommand,
   deleteBuildCache = true,
   cwd,
   target = 'AWS',
@@ -200,6 +198,7 @@ async function buildCommand({
     });
 
     // Get BuildId
+    // TODO: Should be part of buildResult since it's already there
     const entryDirectory = path.dirname(entrypoint);
     const entryPath = path.join(workPath, entryDirectory);
     const buildId = await fs.readFile(

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -188,6 +188,7 @@ async function buildCommand({
       files,
       workPath: mode === 'download' ? tmpDir!.name : cwd,
       entrypoint,
+      repoRootPath: workspaceRoot,
       config: { sharedLambdas: true, installCommand },
       meta: {
         isDev: false,

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -167,8 +167,7 @@ async function buildCommand({
 
   const workspaceRoot = findWorkspaceRoot(cwd);
   const repoRootPath = workspaceRoot ?? cwd;
-  const workPath = mode === 'download' ? tmpDir!.name : cwd;
-  // TODO: temp to see if my assumption about location of .next-tf in tests is correct
+  const workPath = mode === 'download' ? tmpDir!.name : repoRootPath;
   const outputDir = path.join(cwd, '.next-tf');
 
   // Ensure that the output dir exists

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -169,8 +169,9 @@ async function buildCommand({
 
   const workspaceRoot = findWorkspaceRoot(cwd);
   const repoRootPath = workspaceRoot ?? cwd;
-  const outputDir = path.join(cwd, '.next-tf');
-  const workPath = mode === 'download' ? tmpDir!.name : repoRootPath;
+  // TODO: temp to see if my assumption about location of .next-tf in tests is correct
+  const outputDir = path.join(repoRootPath, '.next-tf');
+  const workPath = mode === 'download' ? tmpDir!.name : cwd;
 
   // Ensure that the output dir exists
   fs.ensureDirSync(outputDir);

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -185,7 +185,8 @@ async function buildCommand({
 
     const buildResult = await build({
       files,
-      workPath,
+      workPath: cwd,
+      base: workPath,
       entrypoint,
       config: { sharedLambdas: true },
       meta: {

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -145,6 +145,7 @@ interface BuildProps {
   skipDownload?: boolean;
   logLevel?: 'verbose' | 'none';
   deleteBuildCache?: boolean;
+  installCommand?: string;
   cwd: string;
   target?: 'AWS';
 }
@@ -152,6 +153,7 @@ interface BuildProps {
 async function buildCommand({
   skipDownload = false,
   logLevel,
+  installCommand,
   deleteBuildCache = true,
   cwd,
   target = 'AWS',
@@ -187,7 +189,7 @@ async function buildCommand({
       workPath: mode === 'download' ? tmpDir!.name : cwd,
       base: mode === 'download' ? tmpDir!.name : repoRootPath,
       entrypoint,
-      config: { sharedLambdas: true },
+      config: { sharedLambdas: true, installCommand },
       meta: {
         isDev: false,
         // @ts-ignore

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -188,7 +188,7 @@ async function buildCommand({
       files,
       workPath: mode === 'download' ? tmpDir!.name : cwd,
       entrypoint,
-      repoRootPath: workspaceRoot,
+      repoRootPath: workspaceRoot ? workspaceRoot : undefined,
       config: { sharedLambdas: true, installCommand },
       meta: {
         isDev: false,

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -167,7 +167,6 @@ async function buildCommand({
 
   const workspaceRoot = findWorkspaceRoot(cwd);
   const repoRootPath = workspaceRoot ?? cwd;
-  const workPath = mode === 'download' ? tmpDir!.name : repoRootPath;
   const outputDir = path.join(cwd, '.next-tf');
 
   // Ensure that the output dir exists
@@ -178,7 +177,7 @@ async function buildCommand({
   try {
     // Entrypoint is the relative path to the package.json or next.config.js
     // from repoRootPath
-    const entrypoint = findEntryPoint(repoRootPath, cwd);
+    const entrypoint = 'package.json';
     const lambdas: Lambdas = {};
     const prerenders: Prerenders = {};
     const staticWebsiteFiles: StaticWebsiteFiles = {};
@@ -198,10 +197,8 @@ async function buildCommand({
 
     // Get BuildId
     // TODO: Should be part of buildResult since it's already there
-    const entryDirectory = path.dirname(entrypoint);
-    const entryPath = path.join(workPath, entryDirectory);
     const buildId = await fs.readFile(
-      path.join(entryPath, '.next', 'BUILD_ID'),
+      path.join(mode === 'download' ? tmpDir!.name : cwd, '.next', 'BUILD_ID'),
       'utf8'
     );
 

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -179,7 +179,7 @@ async function buildCommand({
   try {
     // Entrypoint is the relative path to the package.json or next.config.js
     // from repoRootPath
-    const entrypoint = 'package.json';
+    const entrypoint = workspaceRoot ? path.join(path.relative(workspaceRoot, cwd), 'package.json') : 'package.json';
     const lambdas: Lambdas = {};
     const prerenders: Prerenders = {};
     const staticWebsiteFiles: StaticWebsiteFiles = {};
@@ -187,7 +187,6 @@ async function buildCommand({
     const buildResult = await build({
       files,
       workPath: mode === 'download' ? tmpDir!.name : cwd,
-      base: mode === 'download' ? tmpDir!.name : repoRootPath,
       entrypoint,
       config: { sharedLambdas: true, installCommand },
       meta: {


### PR DESCRIPTION
I guess one of the issues would be to now run yarn on the root in download mode? I guess this already makes `--skipDownload` work, but the complexity lies in the `tempDir` needing two package.json's I guess 😅 