### PR TITLE
allow for the deploy trigger to assume a role

### DIFF
--- a/packages/deploy-trigger/src/create-invalidation.ts
+++ b/packages/deploy-trigger/src/create-invalidation.ts
@@ -1,4 +1,4 @@
-import { CloudFront } from 'aws-sdk';
+import { CloudFront, STS } from 'aws-sdk';
 
 import { generateRandomId } from './utils';
 
@@ -21,10 +21,16 @@ function chunkArray<T>(array: T[], chunkSize: number): T[][] {
 
 export async function createInvalidation(
   distributionId: string,
-  invalidationPaths: string[]
+  invalidationPaths: string[],
+  credentials?: STS.Credentials
 ) {
   const cloudFront = new CloudFront({
     apiVersion: '2020-05-31',
+    credentials: credentials ? {
+      accessKeyId: credentials.AccessKeyId,
+      secretAccessKey: credentials.SecretAccessKey,
+      sessionToken: credentials.SessionToken
+    } : undefined
   });
 
   const invalidationChunks = chunkArray(

--- a/packages/deploy-trigger/src/get-or-create-manifest.ts
+++ b/packages/deploy-trigger/src/get-or-create-manifest.ts
@@ -1,4 +1,4 @@
-import { S3 } from 'aws-sdk';
+import aws, { S3 } from 'aws-sdk';
 
 import { manifestVersion } from './constants';
 import { FileResult, Manifest, ManifestFile } from './types';
@@ -14,7 +14,7 @@ async function getAllObjectsFromBucket(
 
   while (hasMore) {
     const response = await s3
-      .listObjectsV2({ Bucket: bucketId, ContinuationToken })
+      .listObjectsV2({ Bucket: bucketId, ContinuationToken, })
       .promise();
 
     if (response.Contents) {
@@ -37,7 +37,7 @@ async function getAllObjectsFromBucket(
 export async function getOrCreateManifest(
   s3: S3,
   bucketId: string,
-  deploymentConfigurationKey: string
+  deploymentConfigurationKey: string,
 ): Promise<Manifest> {
   let manifest: Manifest | undefined;
 
@@ -46,6 +46,7 @@ export async function getOrCreateManifest(
       .getObject({
         Key: deploymentConfigurationKey,
         Bucket: bucketId,
+
       })
       .promise();
 

--- a/packages/deploy-trigger/src/get-or-create-manifest.ts
+++ b/packages/deploy-trigger/src/get-or-create-manifest.ts
@@ -1,4 +1,4 @@
-import aws, { S3 } from 'aws-sdk';
+import { S3 } from 'aws-sdk';
 
 import { manifestVersion } from './constants';
 import { FileResult, Manifest, ManifestFile } from './types';

--- a/packages/deploy-trigger/src/handler.ts
+++ b/packages/deploy-trigger/src/handler.ts
@@ -89,5 +89,5 @@ export const handler: S3Handler = async function (event) {
   });
 
   // Invalidate the paths from the CloudFront distribution
-  await createInvalidation(distributionId, invalidate);
+  await createInvalidation(distributionId, invalidate, credentials);
 };


### PR DESCRIPTION
When we're using a role in TF, using `assume_role` it would be amazing if we could use this in the `deploy-trigger` this would make life a lot easier when account separation is present on AWS.

Main goal would be to enable us to carry something like this over

```
provider "aws" {
  region = "us-east-1"

  assume_role {
    role_arn = "some-role"
  }
}
```

We would just need to decide on how we pass in the role and assume it 😅 