### PR TITLE
Enable attaching lambda to a VPC

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -68,6 +68,14 @@ resource "aws_iam_role_policy_attachment" "lambda_logs" {
   policy_arn = aws_iam_policy.lambda_logging.arn
 }
 
+resource "aws_iam_role_policy_attachment" "lambda_vpc" {
+  for_each = var.lambda_attach_to_vpc ? local.lambdas : {}
+
+  role       = aws_iam_role.lambda[each.key].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+
 ####################################
 # Additional policy JSON (λ Next.js)
 ####################################

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,14 @@ resource "aws_lambda_function" "this" {
     }
   }
 
+  dynamic "vpc_config" {
+    for_each = var.lambda_attach_to_vpc ? [true] : []
+    content {
+      security_group_ids = var.vpc_security_group_ids
+      subnet_ids         = var.vpc_subnet_ids
+    }
+  }
+
   depends_on = [aws_iam_role_policy_attachment.lambda_logs, aws_cloudwatch_log_group.this]
 }
 

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -82,14 +82,14 @@ variable "cloudfront_geo_restriction" {
   description = "Options to control distribution of content, object with restriction_type and locations."
   type = object({
     restriction_type = string,
-    locations = list(string),
+    locations        = list(string),
   })
   default = {
     restriction_type = "none"
-    locations = []
+    locations        = []
   }
   validation {
-    condition = contains(["none", "blacklist", "whitelist"], var.cloudfront_geo_restriction.restriction_type)
+    condition     = contains(["none", "blacklist", "whitelist"], var.cloudfront_geo_restriction.restriction_type)
     error_message = "The restriction_type must be \"none\", \"blacklist\", or \"whitelist\"."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,24 @@ variable "lambda_role_permissions_boundary" {
   default     = null
 }
 
+variable "lambda_attach_to_vpc" {
+  type        = bool
+  description = "Set to true if the Lambda functions should be attached to a VPC. Use this setting if VPC resources should be accessed by the Lambda functions. When setting this to true, use vpc_security_group_ids and vpc_subnet_ids to specify the VPC networking. Note that attaching to a VPC would introduce a delay on to cold starts"
+  default     = false
+}
+
+variable "vpc_subnet_ids" {
+  type        = list(string)
+  description = "The list of VPC subnet IDs to attach the Lambda functions. lambda_attach_to_vpc should be set to true for these to be applied."
+  default     = []
+}
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "The list of Security Group IDs to be used by the Lambda functions. lambda_attach_to_vpc should be set to true for these to be applied."
+  default     = []
+}
+
 #########################
 # Cloudfront Distribution
 #########################


### PR DESCRIPTION
This change introduces three new variables.
1. `lambda_attach_to_vpc` - a flag to allow attaching to a provided VPC
2. `vpc_security_group_ids` - a list of security group ids to associate the
function with
3. `vpc_subnet_ids` - a list of subnet ids to attach the function to

The values for these variables are set to the default disable state to
avoid this being a breaking change, and considering the fact that unatt-
ached state would be the default for most use cases.