### PR TITLE
Queue CloudFront invalidations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "random_id" "function_name" {
 # Lambdas
 #########
 
-# Static deployment to S3 website
+# Static deployment to S3 website and handles CloudFront invalidations
 module "statics_deploy" {
   source = "./modules/statics-deploy"
 
@@ -45,9 +45,11 @@ module "statics_deploy" {
   debug_use_local_packages         = var.debug_use_local_packages
   cloudfront_id                    = module.proxy.cloudfront_id
   cloudfront_arn                   = module.proxy.cloudfront_arn
-  tags                             = var.tags
   lambda_role_permissions_boundary = var.lambda_role_permissions_boundary
   use_awscli_for_static_upload     = var.use_awscli_for_static_upload
+
+  deployment_name = var.deployment_name
+  tags            = var.tags
 }
 
 # Lambda

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -1,9 +1,6 @@
 locals {
-  lambda_policies = [
-    aws_iam_policy.access_static_upload.arn,
-    aws_iam_policy.access_static_deploy.arn
-  ]
-  manifest_key = "_tf-next/deployment.json"
+  manifest_key   = "_tf-next/deployment.json"
+  lambda_timeout = 60
 }
 
 ########################
@@ -20,20 +17,6 @@ resource "aws_s3_bucket" "static_upload" {
   versioning {
     enabled = true
   }
-}
-
-data "aws_iam_policy_document" "access_static_upload" {
-  statement {
-    actions   = ["s3:GetObject", "s3:GetObjectVersion", "s3:DeleteObject", "s3:DeleteObjectVersion"]
-    resources = ["${aws_s3_bucket.static_upload.arn}/*"]
-  }
-}
-
-resource "aws_iam_policy" "access_static_upload" {
-  name_prefix = "next-tf"
-  description = "S3 access for ${aws_s3_bucket.static_upload.id} bucket"
-
-  policy = data.aws_iam_policy_document.access_static_upload.json
 }
 
 resource "aws_s3_bucket_notification" "on_create" {
@@ -104,9 +87,17 @@ resource "aws_s3_bucket_policy" "origin_access" {
   policy = data.aws_iam_policy_document.cf_access.json
 }
 
-# Lambda permissions for updating the static files bucket
-# and to create CloudFront invalidations
+########
+# Lambda
+########
 
+# TODO: Look into if it would be more sense to combine all policies here into
+# a single ressorce
+
+#
+# Lambda permissions for updating the static files bucket and to create
+# CloudFront invalidations
+#
 data "aws_iam_policy_document" "access_static_deploy" {
   statement {
     actions = [
@@ -138,9 +129,80 @@ resource "aws_iam_policy" "access_static_deploy" {
   policy = data.aws_iam_policy_document.access_static_deploy.json
 }
 
-########
-# Lambda
-########
+
+#
+# Lambda permission to download the zipped static uploads package
+#
+data "aws_iam_policy_document" "access_static_upload" {
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:DeleteObject",
+      "s3:DeleteObjectVersion"
+    ]
+    resources = ["${aws_s3_bucket.static_upload.arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "access_static_upload" {
+  name_prefix = "next-tf"
+  description = "S3 access for ${aws_s3_bucket.static_upload.id} bucket"
+
+  policy = data.aws_iam_policy_document.access_static_upload.json
+}
+
+#
+# Lambda permission to access the SQS queue
+#
+data "aws_iam_policy_document" "access_sqs_queue" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    # TODO: Check if we can be more precise here
+    resources = [
+      "arn:aws:logs:*:*:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:SendMessage",
+      "sqs:GetQueueUrl",
+      "sqs:GetQueueAttributes",
+      "sqs:ChangeMessageVisibility",
+    ]
+
+    resources = [
+      aws_sqs_queue.this.arn
+    ]
+  }
+
+  statement {
+    actions = [
+      "sqs:ListQueues",
+    ]
+
+    # TODO: Check if we can be more precise here
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "access_sqs_queue" {
+  name_prefix = "next-tf"
+  description = "SQS access for ${aws_sqs_queue.this.id} queue"
+
+  policy = data.aws_iam_policy_document.access_sqs_queue.json
+}
+
 
 module "lambda_content" {
   source  = "dealmore/download/npm"
@@ -150,6 +212,14 @@ module "lambda_content" {
   module_version = var.deploy_trigger_module_version
   path_to_file   = "dist.zip"
   use_local      = var.debug_use_local_packages
+}
+
+locals {
+  lambda_policies = [
+    aws_iam_policy.access_static_upload.arn,
+    aws_iam_policy.access_static_deploy.arn,
+    aws_iam_policy.access_sqs_queue.arn,
+  ]
 }
 
 resource "random_id" "function_name" {
@@ -166,7 +236,7 @@ module "deploy_trigger" {
   handler                   = "handler.handler"
   runtime                   = "nodejs14.x"
   memory_size               = 1024
-  timeout                   = 60
+  timeout                   = locals.lambda_timeout
   publish                   = true
   tags                      = var.tags
   role_permissions_boundary = var.lambda_role_permissions_boundary
@@ -233,4 +303,39 @@ resource "null_resource" "static_s3_upload" {
   depends_on = [
     aws_s3_bucket_notification.on_create
   ]
+}
+
+################################
+# SQS Queue
+# (For CloudFront invalidations)
+################################
+resource "aws_sns_topic" "this" {
+  name_prefix = var.deployment_name
+
+  tags = var.tags
+}
+
+resource "aws_sqs_queue" "this" {
+  name_prefix               = var.deployment_name
+  message_retention_seconds = var.sqs_message_retention_seconds
+  receive_wait_time_seconds = var.sqs_receive_wait_time_seconds
+
+  # SQS visibility_timeout_seconds must be >= lambda fn timeout,
+  # aws reccomends at least 6 times the lambda
+  # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-queueconfig
+  visibility_timeout_seconds = locals.lambda_timeout * 6
+
+  tags = var.tags
+}
+
+resource "aws_sns_topic_subscription" "this" {
+  topic_arn = aws_sns_topic.this.arn
+  endpoint  = aws_sqs_queue.this.arn
+  protocol  = "sqs"
+}
+
+resource "aws_lambda_event_source_mapping" "this" {
+  batch_size       = 10 # Maximum batch size for SQS
+  event_source_arn = aws_sqs_queue.this.arn
+  function_name    = module.deploy_trigger.this_lambda_function_arn
 }

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -158,19 +158,6 @@ resource "aws_iam_policy" "access_static_upload" {
 data "aws_iam_policy_document" "access_sqs_queue" {
   statement {
     actions = [
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
-    # TODO: Check if we can be more precise here
-    resources = [
-      "arn:aws:logs:*:*:*",
-    ]
-  }
-
-  statement {
-    actions = [
       "sqs:ReceiveMessage",
       "sqs:DeleteMessage",
       "sqs:SendMessage",
@@ -181,17 +168,6 @@ data "aws_iam_policy_document" "access_sqs_queue" {
 
     resources = [
       aws_sqs_queue.this.arn
-    ]
-  }
-
-  statement {
-    actions = [
-      "sqs:ListQueues",
-    ]
-
-    # TODO: Check if we can be more precise here
-    resources = [
-      "*",
     ]
   }
 }

--- a/modules/statics-deploy/variables.tf
+++ b/modules/statics-deploy/variables.tf
@@ -2,11 +2,6 @@ variable "static_files_archive" {
   type = string
 }
 
-variable "debug_use_local_packages" {
-  type    = bool
-  default = false
-}
-
 variable "deploy_trigger_module_version" {
   type    = string
   default = "0.3.0"
@@ -26,17 +21,45 @@ variable "cloudfront_arn" {
   type        = string
 }
 
-variable "tags" {
-  type    = map(string)
-  default = {}
-}
-
 variable "lambda_role_permissions_boundary" {
   type    = string
   default = null
 }
 
 variable "use_awscli_for_static_upload" {
+  type    = bool
+  default = false
+}
+
+###########
+# SQS Queue
+###########
+variable "sqs_message_retention_seconds" {
+  type    = number
+  default = 86400
+}
+
+variable "sqs_receive_wait_time_seconds" {
+  type    = number
+  default = 10
+}
+
+##########
+# Labeling
+##########
+variable "deployment_name" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+#######
+# Debug
+#######
+variable "debug_use_local_packages" {
   type    = bool
   default = false
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@dealmore/sammy": "^1.6.1",
-    "@types/aws-lambda": "^8.10.64",
+    "@types/aws-lambda": "^8.10.76",
     "@types/hjson": "^2.4.2",
     "@types/jest": "^26.0.19",
     "@types/node": "^14.0.0",
@@ -26,7 +26,7 @@
     "prettier": "^2.0.5",
     "tmp": "^0.2.1",
     "ts-jest": "^26.5.5",
-    "typescript": "^4.1.3"
+    "typescript": "^4.2.4"
   },
   "resolutions": {
     "aws-sdk": "2.804.0",

--- a/packages/deploy-trigger/package.json
+++ b/packages/deploy-trigger/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/archiver": "^5.1.0",
-    "@types/aws-lambda": "^8.10.56",
+    "@types/aws-lambda": "^8.10.76",
     "@types/mime": "^2.0.2",
     "@types/tmp": "^0.2.0",
     "@types/unzipper": "^0.10.3",

--- a/packages/deploy-trigger/src/__test__/create-invalidation.test.ts
+++ b/packages/deploy-trigger/src/__test__/create-invalidation.test.ts
@@ -1,0 +1,102 @@
+import {
+  createInvalidationChunk,
+  prepareInvalidations,
+} from '../create-invalidation';
+
+describe('prepareInvalidations', () => {
+  test('Collapse multiPaths', async () => {
+    const invalidationPaths = ['a/b*', 'a*', 'c/d**', 'c*'];
+    const [multiPaths, singlePaths] = prepareInvalidations(invalidationPaths);
+
+    expect(singlePaths.length).toBe(0);
+    expect(multiPaths).toEqual(['a*', 'c*']);
+  });
+
+  test('Remove single paths that are caught by multiPath', () => {
+    const invalidationPaths = ['a*', 'aaa', 'bbb'];
+    const [multiPaths, singlePaths] = prepareInvalidations(invalidationPaths);
+
+    expect(singlePaths).toEqual(['bbb']);
+    expect(multiPaths).toEqual(['a*']);
+  });
+});
+
+describe('createInvalidationChunk', () => {
+  const maxMultiPaths = 15;
+  const maxTotalPaths = 3000;
+
+  test('Full singlePaths', () => {
+    const singlePaths = [...Array(maxTotalPaths).keys()].map(
+      () => 'singlePath'
+    );
+    const multiPaths = [...Array(maxMultiPaths).keys()].map(() => 'multiPath');
+
+    const [pathsChunk, newMultiPaths, newSinglePaths] = createInvalidationChunk(
+      multiPaths,
+      singlePaths,
+      maxMultiPaths,
+      maxTotalPaths
+    );
+
+    expect(pathsChunk.length).toBe(maxTotalPaths);
+    expect(newSinglePaths.length).toBe(0);
+    expect(newMultiPaths.length).toBe(maxMultiPaths);
+  });
+
+  test('Overfull singlePaths', () => {
+    const overfillSinglePathsBy = 100;
+    const singlePaths = [
+      ...Array(maxTotalPaths + overfillSinglePathsBy).keys(),
+    ].map(() => 'singlePath');
+    const multiPaths = [...Array(maxMultiPaths).keys()].map(() => 'multiPath');
+
+    const [pathsChunk, newMultiPaths, newSinglePaths] = createInvalidationChunk(
+      multiPaths,
+      singlePaths,
+      maxMultiPaths,
+      maxTotalPaths
+    );
+
+    expect(pathsChunk.length).toBe(maxTotalPaths);
+    expect(newSinglePaths.length).toBe(overfillSinglePathsBy);
+    expect(newMultiPaths.length).toBe(maxMultiPaths);
+  });
+
+  test('No singlePaths', () => {
+    const overfillMultiPathsBy = 10;
+    const singlePaths: string[] = [];
+    const multiPaths = [
+      ...Array(maxMultiPaths + overfillMultiPathsBy).keys(),
+    ].map(() => 'multiPath');
+
+    const [pathsChunk, newMultiPaths, newSinglePaths] = createInvalidationChunk(
+      multiPaths,
+      singlePaths,
+      maxMultiPaths,
+      maxTotalPaths
+    );
+
+    expect(pathsChunk.length).toBe(maxMultiPaths);
+    expect(newSinglePaths.length).toBe(0);
+    expect(newMultiPaths.length).toBe(overfillMultiPathsBy);
+  });
+
+  test('Fillup paths with multiPaths', () => {
+    const allowedMultiPaths = 7;
+    const singlePaths = [
+      ...Array(maxTotalPaths - allowedMultiPaths).keys(),
+    ].map(() => 'singlePath');
+    const multiPaths = [...Array(maxMultiPaths).keys()].map(() => 'multiPath');
+
+    const [pathsChunk, newMultiPaths, newSinglePaths] = createInvalidationChunk(
+      multiPaths,
+      singlePaths,
+      maxMultiPaths,
+      maxTotalPaths
+    );
+
+    expect(pathsChunk.length).toBe(maxTotalPaths);
+    expect(newSinglePaths.length).toBe(0);
+    expect(newMultiPaths.length).toBe(maxMultiPaths - allowedMultiPaths);
+  });
+});

--- a/packages/deploy-trigger/src/create-invalidation.ts
+++ b/packages/deploy-trigger/src/create-invalidation.ts
@@ -1,54 +1,136 @@
 import { CloudFront } from 'aws-sdk';
 
-import { generateRandomId } from './utils';
-
 // Number of paths a single invalidation can hold
 // A invalidation should not have more than 15 paths with wildcards (*) at a time
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects%23InvalidationLimits
-//
-// TODO: Find out if we can submit multiple invalidations with 15 invalidation
-// paths at a single time and if they are running sequentially or if we
-// need to take care of this scenario
-// May need a step-function with sleep to make this possible?
-const limitPathsPerInvalidation = 15;
+const limitMultiPathsPerInvalidation = 15;
+const limitTotalPathsPerInvalidation = 3000;
 
-function chunkArray<T>(array: T[], chunkSize: number): T[][] {
-  const R = [];
-  for (let i = 0, len = array.length; i < len; i += chunkSize)
-    R.push(array.slice(i, i + chunkSize));
-  return R;
-}
+/**
+ * Splits the incoming paths into paths with tailing wildcard character (`*`),
+ * called multiPaths and regular paths, called singlePaths
+ * @param invalidationPaths
+ * @returns [multiPaths, singlePaths]
+ */
+export function prepareInvalidations(invalidationPaths: string[]) {
+  let multiPaths: string[] = [];
+  let singlePaths: string[] = [];
 
-export async function createInvalidation(
-  distributionId: string,
-  invalidationPaths: string[]
-) {
-  const cloudFront = new CloudFront({
-    apiVersion: '2020-05-31',
-  });
-
-  const invalidationChunks = chunkArray(
-    invalidationPaths,
-    limitPathsPerInvalidation
-  );
-
-  for (const chunk of invalidationChunks) {
-    try {
-      await cloudFront
-        .createInvalidation({
-          DistributionId: distributionId,
-          InvalidationBatch: {
-            CallerReference: `${new Date().getTime()}-${generateRandomId(4)}`,
-            Paths: {
-              Quantity: chunk.length,
-              Items: chunk,
-            },
-          },
-        })
-        .promise();
-    } catch (err) {
-      // See TODO from top
-      console.log(err);
+  // Search through the
+  for (const invalidationPath of invalidationPaths) {
+    // Paths with `*` at the end are multiPaths
+    if (invalidationPath.endsWith('*')) {
+      multiPaths.push(invalidationPath);
+    } else {
+      singlePaths.push(invalidationPath);
     }
   }
+
+  // Normalize multipaths
+  // E.g. we have the following paths:
+  // - /a*
+  // - /a/b*
+  // They can then be combined into
+  // - /a*
+
+  // 1. Sort by length DESC (n...0)
+  // 2. Check for every path if there is a shorter path with the same beginning
+  //    If true then remove the path
+  multiPaths = multiPaths
+    .sort((a, b) => b.length - a.length)
+    .filter((multiPath, index, array) => {
+      // Search for a shorter string that is a substring multiPath
+      for (let i = index + 1; i < array.length; i++) {
+        // Cut the tailing `*`
+        const pathWithoutTail = array[i].substr(0, array[i].length - 1);
+        if (multiPath.startsWith(pathWithoutTail)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+  // Check if regular paths are already caught by a multiPath
+  singlePaths = singlePaths.filter((singlePath) => {
+    for (const multiPath of multiPaths) {
+      // Cut the tailing `*`
+      const pathWithoutTail = multiPath.substr(0, multiPath.length - 1);
+
+      if (singlePath.startsWith(pathWithoutTail)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+
+  return [multiPaths, singlePaths];
+}
+
+/**
+ * Creates a chunk of paths for a CloudFront invalidation request
+ * @param multiPaths
+ * @param singlePaths
+ * @param maxMultiPaths limit of multiPaths
+ * @param maxTotalPaths limit of total paths that can be included in an invalidation
+ * @returns
+ */
+export function createInvalidationChunk(
+  multiPaths: string[],
+  singlePaths: string[],
+  maxMultiPaths: number,
+  maxTotalPaths: number
+) {
+  let pathsChunk: string[] = [];
+  let newSinglePaths: string[] = singlePaths;
+  let newMultiPaths: string[] = multiPaths;
+
+  // First, try to put as many singlePaths into an invalidation chunk as possible
+  const singlePathIndex = Math.min(singlePaths.length, maxTotalPaths);
+  if (singlePathIndex > 0) {
+    pathsChunk = singlePaths.slice(0, singlePathIndex);
+    newSinglePaths = singlePaths.slice(singlePathIndex);
+  }
+
+  // Check if chunk is already full and fill the remaining paths with multiPaths
+  const numOfAvailablePathsInChunk = maxTotalPaths - pathsChunk.length;
+  const numOfAvailableMultiPathsInChunk = Math.min(
+    numOfAvailablePathsInChunk,
+    maxMultiPaths
+  );
+  if (numOfAvailableMultiPathsInChunk > 0) {
+    pathsChunk.push(...multiPaths.slice(0, numOfAvailableMultiPathsInChunk));
+    newMultiPaths = multiPaths.slice(numOfAvailableMultiPathsInChunk);
+  }
+
+  return [pathsChunk, newMultiPaths, newSinglePaths];
+}
+
+/**
+ * Creates a batch of paths that can be used as CloudFront invalidation
+ * @param invalidationPaths
+ * @returns
+ */
+export function createInvalidation(
+  invalidationId: string,
+  multiPaths: string[],
+  singlePaths: string[]
+): [CloudFront.InvalidationBatch, string[], string[]] {
+  const [pathsChunk, newMultiPaths, newSinglePaths] = createInvalidationChunk(
+    multiPaths,
+    singlePaths,
+    limitMultiPathsPerInvalidation,
+    limitTotalPathsPerInvalidation
+  );
+
+  const cloudFrontInvalidationBatch: CloudFront.InvalidationBatch = {
+    CallerReference: `${new Date().getTime()}-${invalidationId}`,
+    Paths: {
+      Quantity: pathsChunk.length,
+      Items: pathsChunk,
+    },
+  };
+
+  return [cloudFrontInvalidationBatch, newMultiPaths, newSinglePaths];
 }

--- a/packages/deploy-trigger/src/declarations.ts
+++ b/packages/deploy-trigger/src/declarations.ts
@@ -3,5 +3,6 @@ declare namespace NodeJS {
     TARGET_BUCKET: string;
     EXPIRE_AFTER_DAYS: string;
     DISTRIBUTION_ID: string;
+    SQS_QUEUE_URL: string;
   }
 }

--- a/packages/deploy-trigger/src/handler.ts
+++ b/packages/deploy-trigger/src/handler.ts
@@ -1,15 +1,29 @@
-import { S3Handler } from 'aws-lambda';
-import { S3 } from 'aws-sdk';
+import { S3Event, S3EventRecord, SQSEvent, SQSRecord } from 'aws-lambda';
+import { S3, CloudFront, SQS } from 'aws-sdk';
 
 import { deployTrigger } from './deploy-trigger';
 import { ExpireValue } from './types';
 import { updateManifest } from './update-manifest';
 import { deploymentConfigurationKey } from './constants';
 import { getOrCreateManifest } from './get-or-create-manifest';
-import { createInvalidation } from './create-invalidation';
+import {
+  createInvalidation,
+  prepareInvalidations,
+} from './create-invalidation';
+import { generateRandomId } from './utils';
+
+interface InvalidationSQSMessage {
+  id: string;
+  distributionId: string;
+  multiPaths: string[];
+  singlePaths: string[];
+}
 
 // Default value after how many days an old deployment should be expired
 const defaultExpireAfterDays = 30;
+
+// Timeout in seconds to wait after an invalidation is send to SQS
+const timeOutBetweenInvalidations = 60;
 
 function parseExpireAfterDays() {
   if (process.env.EXPIRE_AFTER_DAYS) {
@@ -33,16 +47,90 @@ function parseExpireAfterDays() {
   return defaultExpireAfterDays;
 }
 
-export const handler: S3Handler = async function (event) {
+async function createCloudFrontInvalidation(
+  incomingMultiPaths: string[],
+  incomingSinglePaths: string[],
+  distributionId: string
+) {
+  // Invalidate the paths from the CloudFront distribution
+  const cloudFrontClient = new CloudFront({
+    apiVersion: '2020-05-31',
+  });
+
+  const invalidationId = generateRandomId(4);
+  const [InvalidationBatch, multiPaths, singlePaths] = createInvalidation(
+    invalidationId,
+    incomingMultiPaths,
+    incomingSinglePaths
+  );
+
+  try {
+    await cloudFrontClient
+      .createInvalidation({
+        DistributionId: distributionId,
+        InvalidationBatch,
+      })
+      .promise();
+  } catch (err) {
+    // TODO: Find way to handle errors here
+    console.log(err);
+  }
+
+  // Create SQS event if there are paths left to invalidate
+  if (multiPaths.length + singlePaths.length > 0) {
+    const MessageBody: InvalidationSQSMessage = {
+      id: invalidationId,
+      distributionId,
+      multiPaths,
+      singlePaths,
+    };
+
+    const sqsClient = new SQS();
+
+    try {
+      await sqsClient
+        .sendMessage({
+          QueueUrl: process.env.SQS_QUEUE_URL,
+          MessageBody: JSON.stringify(MessageBody),
+          DelaySeconds: timeOutBetweenInvalidations,
+        })
+        .promise();
+    } catch (err) {
+      // TODO: Find way to handle errors here
+      console.log(err);
+    }
+  }
+}
+
+/**
+ * Handler of the Lambda that is invoked
+ * Trigger can be one of the following:
+ *   - S3 (From static upload)
+ *   - SQS (Queued CloudFront invalidations)
+ * @param event S3Event or SQSEvent
+ */
+export const handler = async function (event: S3Event | SQSEvent) {
+  // SQS invokes can contain up to 10 records
+  for (const Record of event.Records) {
+    if ('s3' in Record) {
+      // Check if S3 Record
+      await s3Handler(Record);
+    } else {
+      await sqsHandler(Record);
+    }
+  }
+};
+
+async function s3Handler(Record: S3EventRecord) {
   const s3 = new S3({ apiVersion: '2006-03-01' });
   const deployBucket = process.env.TARGET_BUCKET;
   const distributionId = process.env.DISTRIBUTION_ID;
   const expireAfterDays: ExpireValue = parseExpireAfterDays();
 
   // Get needed information of the event
-  const { object } = event.Records[0].s3;
+  const { object } = Record.s3;
   const { versionId, key } = object;
-  const sourceBucket = event.Records[0].s3.bucket.name;
+  const sourceBucket = Record.s3.bucket.name;
 
   const manifest = await getOrCreateManifest(
     s3,
@@ -60,7 +148,7 @@ export const handler: S3Handler = async function (event) {
   });
 
   // Update the manifest
-  const { invalidate } = await updateManifest({
+  const { invalidate: invalidationPaths } = await updateManifest({
     s3,
     bucket: deployBucket,
     expireAfterDays,
@@ -70,6 +158,16 @@ export const handler: S3Handler = async function (event) {
     manifest,
   });
 
-  // Invalidate the paths from the CloudFront distribution
-  await createInvalidation(distributionId, invalidate);
-};
+  const [multiPaths, singlePaths] = prepareInvalidations(invalidationPaths);
+  await createCloudFrontInvalidation(multiPaths, singlePaths, distributionId);
+}
+
+async function sqsHandler(Record: SQSRecord) {
+  const body = JSON.parse(Record.body) as InvalidationSQSMessage;
+
+  await createCloudFrontInvalidation(
+    body.multiPaths,
+    body.singlePaths,
+    body.distributionId
+  );
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@types/aws-lambda": "8.10.64",
+    "@types/aws-lambda": "^8.10.76",
     "@types/buffer-crc32": "0.2.0",
     "@types/find-up": "4.0.0",
     "@types/fs-extra": "8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -701,16 +701,6 @@
   dependencies:
     "@types/glob" "*"
 
-"@types/aws-lambda@8.10.64", "@types/aws-lambda@^8.10.64":
-  version "8.10.64"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.64.tgz#4bdcb725aef96bef0cb1decf19c7efff1df22fe7"
-  integrity sha512-LRKk2UQCSi7BsO5TlfSI8cTNpOGz+MH6+RXEWtuZmxJficQgxwEYJDiKVirzgyiHce0L0F4CqCVvKTwblAeOUw==
-
-"@types/aws-lambda@^8.10.56":
-  version "8.10.56"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.56.tgz#24fc61bf628db86412bb4f28da051df4baa532d6"
-  integrity sha512-jaxu5br/KYxhNBNmr2GoVhIUady2zNsvSRCa4kCHW+GcM4ladPhfEyeJkkNMGo/IlVAfpcPYTsSzhYWZoSgZXA==
-
 "@types/aws-lambda@^8.10.76":
   version "8.10.76"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.76.tgz#a20191677f1f5e32fe1f26739b1d6fbbea9cf636"
@@ -6194,6 +6184,11 @@ typescript@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 unbox-primitive@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This basically uses the same concept as [this terraform module](https://github.com/dirt-simple/terraform-aws-cloudfront-invalidation), by queuing invalidations that are too long (e.g. that contain over 15 wildcard invalidations) so that they can be processed sequentially by CloudFront.

Fixes #48.