### PR TITLE
Proxy: Upgrade runtime to nodejs14.x

### DIFF
--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -7,11 +7,9 @@ variable "proxy_module_version" {
   default = "0.5.0"
 }
 
-# Note that Lambda@Edge currently does not support `nodejs14.x` runtime
-# https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html#lambda-requirements-lambda-function-configuration
 variable "lambda_default_runtime" {
   type    = string
-  default = "nodejs12.x"
+  default = "nodejs14.x"
 }
 
 variable "lambda_role_permissions_boundary" {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.76",
-    "@types/node": "^12.0.0",
     "@types/node-fetch": "^2.5.7",
     "@vercel/ncc": "^0.27.0",
     "get-port": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,11 +866,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.6.1.tgz#32d43390d5c62c5b6ec486a9bc9c59544de39a08"
   integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
 
-"@types/node@^12.0.0":
-  version "12.20.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.11.tgz#980832cd56efafff8c18aa148c4085eb02a483f4"
-  integrity sha512-gema+apZ6qLQK7k7F0dGkGCWQYsL0qqKORWOQO6tq46q+x+1C0vbOiOqOwRVlh4RAdbQwV/j/ryr3u5NOG1fPQ==
-
 "@types/node@^14.0.0":
   version "14.14.35"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"


### PR DESCRIPTION
Upgrades the Lambda@Edge runtime of the proxy module to `nodejs14.x` since it is now officially supported:
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html#lambda-requirements-lambda-function-configuration
