### PR TITLE
proxy: Fixes external rewrite configuration

### DIFF
--- a/packages/proxy/src/__test__/handler.test.ts
+++ b/packages/proxy/src/__test__/handler.test.ts
@@ -162,7 +162,7 @@ describe('[proxy] Handler', () => {
       expect(result.origin?.custom).toEqual(
         expect.objectContaining({
           domainName: 'example.com',
-          path: '/',
+          path: '',
           port: 80,
           protocol: 'http',
         })
@@ -284,7 +284,7 @@ describe('[proxy] Handler', () => {
       expect(result.origin?.custom).toEqual(
         expect.objectContaining({
           domainName: 'example.com',
-          path: '/',
+          path: '',
           port: 443,
           protocol: 'https',
         })
@@ -406,7 +406,7 @@ describe('[proxy] Handler', () => {
       expect(result.origin?.custom).toEqual(
         expect.objectContaining({
           domainName: 'example.com',
-          path: '/',
+          path: '',
           port: 666,
           protocol: 'https',
         })
@@ -528,7 +528,7 @@ describe('[proxy] Handler', () => {
       expect(result.origin?.custom).toEqual(
         expect.objectContaining({
           domainName: 'sub.example.com',
-          path: '/',
+          path: '',
           port: 443,
           protocol: 'https',
         })

--- a/packages/proxy/src/util/custom-origin.ts
+++ b/packages/proxy/src/util/custom-origin.ts
@@ -24,7 +24,7 @@ export function createCustomOriginFromUrl(
   return [
     {
       domainName: _url.hostname,
-      path: '/',
+      path: '', // Must not have a tailing / at the end
       customHeaders: {},
       keepaliveTimeout: 5,
       port,


### PR DESCRIPTION
Fixes an issue with the external rewrite configuration where CloudFront was not able to fulfill the request because the origin path was set to `"/"` instead of `""` (empty string).