### PR TITLE
Proxy: Fix root route rewrites

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -295,7 +295,7 @@ resource "aws_cloudfront_cache_policy" "this" {
 locals {
   # CloudFront default root object
   ################################
-  cloudfront_default_root_object = "index"
+  cloudfront_default_root_object = ""
 
   # CloudFront Origins
   ####################

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@vercel/routing-utils": "^1.9.1",
     "abort-controller": "^3.0.0",
-    "node-fetch": "^2.6.1",
-    "pcre-to-regexp": "^1.1.0"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.76",

--- a/packages/proxy/src/__test__/handler.test.ts
+++ b/packages/proxy/src/__test__/handler.test.ts
@@ -545,4 +545,133 @@ describe('[proxy] Handler', () => {
     },
     TIMEOUT
   );
+
+  test(
+    'i18n default locale rewrite',
+    async () => {
+      const proxyConfig: ProxyConfig = {
+        lambdaRoutes: [],
+        prerenders: {},
+        staticRoutes: [],
+        routes: [
+          {
+            src: '^/(?!(?:_next/.*|en|fr\\-FR|nl)(?:/.*|$))(.*)$',
+            dest: '$wildcard/$1',
+            continue: true,
+          },
+          {
+            src: '/',
+            locale: {
+              redirect: {
+                en: '/',
+                'fr-FR': '/fr-FR',
+                nl: '/nl',
+              },
+              cookie: 'NEXT_LOCALE',
+            },
+            continue: true,
+          },
+          {
+            src: '^/$',
+            dest: '/en',
+            continue: true,
+          },
+        ],
+      };
+      const requestPath = '/';
+
+      // Prepare configServer
+      configServer.proxyConfig = proxyConfig;
+
+      // Origin Request
+      // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request
+      const event: CloudFrontRequestEvent = {
+        Records: [
+          {
+            cf: {
+              config: {
+                distributionDomainName: 'd111111abcdef8.cloudfront.net',
+                distributionId: 'EDFDVBD6EXAMPLE',
+                eventType: 'origin-request',
+                requestId:
+                  '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
+              },
+              request: {
+                clientIp: '203.0.113.178',
+                headers: {
+                  'x-forwarded-for': [
+                    {
+                      key: 'X-Forwarded-For',
+                      value: '203.0.113.178',
+                    },
+                  ],
+                  'user-agent': [
+                    {
+                      key: 'User-Agent',
+                      value: 'Amazon CloudFront',
+                    },
+                  ],
+                  via: [
+                    {
+                      key: 'Via',
+                      value:
+                        '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
+                    },
+                  ],
+                  host: [
+                    {
+                      key: 'Host',
+                      value: 'example.org',
+                    },
+                  ],
+                  'cache-control': [
+                    {
+                      key: 'Cache-Control',
+                      value: 'no-cache, cf-no-cache',
+                    },
+                  ],
+                },
+                method: 'GET',
+                origin: {
+                  s3: {
+                    customHeaders: {
+                      'x-env-config-endpoint': [
+                        {
+                          key: 'x-env-config-endpoint',
+                          value: configEndpoint,
+                        },
+                      ],
+                      'x-env-api-endpoint': [
+                        {
+                          key: 'x-env-api-endpoint',
+                          value: 'example.localhost',
+                        },
+                      ],
+                    },
+                    region: 'us-east-1',
+                    authMethod: 'origin-access-identity',
+                    domainName: 's3.localhost',
+                    path: '',
+                  },
+                },
+                querystring: '',
+                uri: requestPath,
+              },
+            },
+          },
+        ],
+      };
+
+      const result = (await handler(event)) as CloudFrontRequest;
+
+      expect(result.origin?.s3).toEqual(
+        expect.objectContaining({
+          domainName: 's3.localhost',
+          path: '',
+        })
+      );
+      expect(result.uri).toBe('/en');
+    },
+    TIMEOUT
+  );
 });

--- a/packages/proxy/src/__test__/handler.test.ts
+++ b/packages/proxy/src/__test__/handler.test.ts
@@ -674,4 +674,152 @@ describe('[proxy] Handler', () => {
     },
     TIMEOUT
   );
+
+  test(
+    'Correctly request /index object from S3 when requesting /',
+    async () => {
+      const proxyConfig: ProxyConfig = {
+        staticRoutes: ['/404', '/500', '/index'],
+        lambdaRoutes: [],
+        routes: [
+          {
+            src: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
+            headers: {
+              Location: '/$1',
+            },
+            status: 308,
+            continue: true,
+          },
+          {
+            src: '/404',
+            status: 404,
+            continue: true,
+          },
+          {
+            handle: 'filesystem',
+          },
+          {
+            handle: 'resource',
+          },
+          {
+            src: '/.*',
+            status: 404,
+          },
+          {
+            handle: 'miss',
+          },
+          {
+            handle: 'rewrite',
+          },
+          {
+            handle: 'hit',
+          },
+          {
+            handle: 'error',
+          },
+          {
+            src: '/.*',
+            dest: '/404',
+            status: 404,
+          },
+        ],
+        prerenders: {},
+      };
+
+      const requestPath = '/';
+
+      // Prepare configServer
+      configServer.proxyConfig = proxyConfig;
+
+      // Origin Request
+      // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request
+      const event: CloudFrontRequestEvent = {
+        Records: [
+          {
+            cf: {
+              config: {
+                distributionDomainName: 'd111111abcdef8.cloudfront.net',
+                distributionId: 'EDFDVBD6EXAMPLE',
+                eventType: 'origin-request',
+                requestId:
+                  '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
+              },
+              request: {
+                clientIp: '203.0.113.178',
+                headers: {
+                  'x-forwarded-for': [
+                    {
+                      key: 'X-Forwarded-For',
+                      value: '203.0.113.178',
+                    },
+                  ],
+                  'user-agent': [
+                    {
+                      key: 'User-Agent',
+                      value: 'Amazon CloudFront',
+                    },
+                  ],
+                  via: [
+                    {
+                      key: 'Via',
+                      value:
+                        '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
+                    },
+                  ],
+                  host: [
+                    {
+                      key: 'Host',
+                      value: 'example.org',
+                    },
+                  ],
+                  'cache-control': [
+                    {
+                      key: 'Cache-Control',
+                      value: 'no-cache, cf-no-cache',
+                    },
+                  ],
+                },
+                method: 'GET',
+                origin: {
+                  s3: {
+                    customHeaders: {
+                      'x-env-config-endpoint': [
+                        {
+                          key: 'x-env-config-endpoint',
+                          value: configEndpoint,
+                        },
+                      ],
+                      'x-env-api-endpoint': [
+                        {
+                          key: 'x-env-api-endpoint',
+                          value: 'example.localhost',
+                        },
+                      ],
+                    },
+                    region: 'us-east-1',
+                    authMethod: 'origin-access-identity',
+                    domainName: 's3.localhost',
+                    path: '',
+                  },
+                },
+                querystring: '',
+                uri: requestPath,
+              },
+            },
+          },
+        ],
+      };
+
+      const result = (await handler(event)) as CloudFrontRequest;
+
+      expect(result.origin?.s3).toEqual(
+        expect.objectContaining({
+          domainName: 's3.localhost',
+          path: '',
+        })
+      );
+      expect(result.uri).toBe('/index');
+    },
+    TIMEOUT
+  );
 });

--- a/packages/proxy/src/__test__/proxy.unit.test.ts
+++ b/packages/proxy/src/__test__/proxy.unit.test.ts
@@ -331,3 +331,74 @@ test('[proxy-unit] External rewrite', () => {
     target: 'url',
   });
 });
+
+test('[proxy-unit] Rewrite with ^ and $', () => {
+  const routesConfig = [
+    {
+      src: '^/$',
+      dest: '/en',
+      continue: true,
+    },
+  ] as Route[];
+
+  const result = new Proxy(routesConfig, [], []).route('/');
+
+  expect(result).toEqual({
+    found: true,
+    dest: '/en',
+    continue: true,
+    status: undefined,
+    headers: {},
+    uri_args: new URLSearchParams(),
+    matched_route: routesConfig[0],
+    matched_route_idx: 0,
+    userDest: true,
+    isDestUrl: false,
+    phase: undefined,
+    target: undefined,
+  });
+});
+
+test('[proxy-unit] i18n default locale', () => {
+  const routesConfig = [
+    {
+      src: '^/(?!(?:_next/.*|en|fr\\-FR|nl)(?:/.*|$))(.*)$',
+      dest: '$wildcard/$1',
+      continue: true,
+    },
+    {
+      src: '/',
+      locale: {
+        redirect: {
+          en: '/',
+          'fr-FR': '/fr-FR',
+          nl: '/nl',
+        },
+        cookie: 'NEXT_LOCALE',
+      },
+      continue: true,
+    },
+    {
+      src: '^/$',
+      dest: '/en',
+      continue: true,
+    },
+  ] as Route[];
+
+  const result = new Proxy(routesConfig, [], []).route('/');
+
+  expect(result).toEqual({
+    found: true,
+    dest: '/en',
+    continue: true,
+    status: undefined,
+    headers: {},
+    uri_args: new URLSearchParams(''),
+    matched_route: routesConfig[2],
+    matched_route_idx: 2,
+    userDest: true,
+    isDestUrl: false,
+    phase: undefined,
+    target: undefined,
+  });
+});

--- a/packages/proxy/src/handler.ts
+++ b/packages/proxy/src/handler.ts
@@ -162,6 +162,10 @@ export async function handler(event: CloudFrontRequestEvent) {
       if (proxyResult.found) {
         request.uri = proxyResult.dest;
       }
+
+      // TODO: Test this
+      // Replace the last / with /index when requesting the resource from S3
+      request.uri.replace(/\/$/, '/index');
     }
 
     headers = { ...proxyResult.headers, ...headers };

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -207,7 +207,10 @@ export class Proxy {
             reqPathname = nextUrl.pathname!;
 
             // Check if we have a static route
-            if (!this.staticRoutes.has(reqPathname)) {
+            // Convert to filePath first, since routes with tailing `/` are
+            // stored as `/index` in filesystem
+            const filePath = reqPathname.replace(/\/$/, '/index');
+            if (!this.staticRoutes.has(filePath)) {
               appendURLSearchParams(searchParams, nextUrl.searchParams);
               continue;
             }

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1,6 +1,5 @@
 import { URL, URLSearchParams } from 'url';
 import { Route, isHandler, HandleValue } from '@vercel/routing-utils';
-import PCRE from 'pcre-to-regexp';
 
 import isURL from './util/is-url';
 import { RouteResult, HTTPHeaders } from './types';
@@ -139,15 +138,13 @@ export class Proxy {
       //////////////////////////////////////////////////////////////////////////
       // Phase 2: Check for source
       const { src, headers } = routeConfig;
-      let keys: string[] = []; // Filled by PCRE in next step
       // Note: Routes are case-insensitive
-      // PCRE tries to match the path to the regex of the route
-      // It also parses the parameters to the keys variable
-      // TODO: Performance: Cache results from PCRE
-      const matcher = PCRE(`%${src}%i`, keys);
+      // TODO: Performance: Cache matcher results
+      const matcher = new RegExp(src, 'i');
       const match = matcher.exec(reqPathname);
 
       if (match !== null) {
+        const keys = Object.keys(match.groups ?? {});
         isContinue = false;
         // The path that should be sent to the target system (lambda or filesystem)
         let destPath: string = reqPathname;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4924,11 +4924,6 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pcre-to-regexp@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pcre-to-regexp/-/pcre-to-regexp-1.1.0.tgz#1c48373d194b982e1416031b41470839fab3ad6c"
-  integrity sha512-KF9XxmUQJ2DIlMj3TqNqY1AWvyvTuIuq11CuuekxyaYMiFuMKGgQrePYMX5bXKLhLG3sDI4CsGAYHPaT7VV7+g==
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"


### PR DESCRIPTION
- Removes default root object from the CloudFront distribution
- Uses default RegEx parser from Node.js
- Append `/index` to routes with tailing `/` when serving them from S3

## ToDo: 
- [x] Test `/index` to routes with tailing `/`

Fixes #139.