### PR TITLE
Bump image optimization module from 10.x.x to 11.x.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ module "next_image" {
   count = var.create_image_optimization ? 1 : 0
 
   source  = "dealmore/next-js-image-optimization/aws"
-  version = "~> 10.0.8"
+  version = ">= 11.0.0"
 
   cloudfront_create_distribution = false
 
@@ -170,6 +170,7 @@ module "next_image" {
 
   source_bucket_id = module.statics_deploy.static_bucket_id
 
+  lambda_memory_size               = var.image_optimization_lambda_memory_size
   lambda_attach_policy_json        = true
   lambda_policy_json               = data.aws_iam_policy_document.access_static_deployment.json
   lambda_role_permissions_boundary = var.lambda_role_permissions_boundary
@@ -376,19 +377,7 @@ locals {
   }
 
   # next/image behavior
-  # TODO: Replace with output from https://github.com/dealmore/terraform-aws-next-js-image-optimization/issues/43
-  cloudfront_ordered_cache_behavior_next_image = var.create_image_optimization ? {
-    path_pattern     = "/_next/image*"
-    allowed_methods  = ["GET", "HEAD"]
-    cached_methods   = ["GET", "HEAD"]
-    target_origin_id = module.next_image[0].cloudfront_origin_id
-
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
-
-    origin_request_policy_id = module.next_image[0].cloudfront_origin_request_policy_id
-    cache_policy_id          = module.next_image[0].cloudfront_cache_policy_id
-  } : null
+  cloudfront_ordered_cache_behavior_next_image = var.create_image_optimization ? module.next_image[0].cloudfront_cache_behavior : null
 
   # Little hack here to create a dynamic object with different number of attributes
   # using filtering: https://www.terraform.io/docs/language/expressions/for.html#filtering-elements

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "create_image_optimization" {
   default     = true
 }
 
+variable "image_optimization_lambda_memory_size" {
+  description = "Amount of memory in MB the worker Lambda Function for image optimization can use. Valid value between 128 MB to 10,240 MB, in 1 MB increments."
+  type        = number
+  default     = 2048
+}
+
 variable "expire_static_assets" {
   description = "Number of days after which static assets from previous deployments should be removed from S3. Set to -1 to disable expiration."
   type        = number


### PR DESCRIPTION
- Bump minor version of [Terraform Next.js Image Optimization module for AWS](https://github.com/dealmore/terraform-aws-next-js-image-optimization) to `11.0.0`
- Adds variable to set the amount of memory that can be used by the image optimization worker
- Uses default cache behavior from the module

Fixes #142.