### PR TITLE
Add an output for the function ARNs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -44,3 +44,15 @@ output "cloudfront_custom_error_response" {
   description = "Preconfigured custom error response the CloudFront distribution should use."
   value       = local.cloudfront_custom_error_response
 }
+
+
+##################################
+# Lambda function
+##################################
+
+output "lambda_functions_arn" {
+  description = "The list of ARNs of the Lambda functions deployed"
+  value = toset([
+    for x in aws_lambda_function.this : x.arn
+  ])
+}


### PR DESCRIPTION
This PR adds the following Output to the Terraform module.

* `lambda_functions_arn` - The list of ARNs of the Lambda functions deployed

These will be useful for any other configuration that needs to be
attached to the functions after they are created, like attaching a
provisioned concurrency configuration.