### PR TITLE
Multiple deployments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -320,6 +320,10 @@ locals {
       {
         name  = "x-env-api-endpoint"
         value = trimprefix(module.api_gateway.apigatewayv2_api_api_endpoint, "https://")
+      },
+      {
+        name  = "x-env-domain-name"
+        value = var.domain_name
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prettier": "^2.0.5",
     "tmp": "^0.2.1",
     "ts-jest": "^26.5.5",
-    "typescript": "^4.2.4",
+    "typescript": "^4.4.2",
     "unzipper": "^0.10.11"
   },
   "resolutions": {

--- a/packages/deploy-trigger/src/__test__/get-or-create-manifest.test.ts
+++ b/packages/deploy-trigger/src/__test__/get-or-create-manifest.test.ts
@@ -58,8 +58,8 @@ describe('deploy-trigger', () => {
       expect(Object.keys(manifest.files).length).toBe(fileNames.length);
       for (const file of fileNames) {
         expect(manifest.files[file]).toBeDefined();
-        expect(manifest.files[file].buildId).toContain(manifest.currentBuild);
-        expect(manifest.files[file].expiredAt).not.toBeDefined();
+        expect(manifest.files[file]?.buildId).toContain(manifest.currentBuild);
+        expect(manifest.files[file]?.expiredAt).not.toBeDefined();
       }
     });
   });

--- a/packages/deploy-trigger/src/create-invalidation.ts
+++ b/packages/deploy-trigger/src/create-invalidation.ts
@@ -12,7 +12,7 @@ const limitTotalPathsPerInvalidation = 3000;
  * @param invalidationPaths
  * @returns [multiPaths, singlePaths]
  */
-export function prepareInvalidations(invalidationPaths: string[]) {
+export function prepareInvalidations(invalidationPaths: string[]): [string[], string[]] {
   let multiPaths: string[] = [];
   let singlePaths: string[] = [];
 
@@ -38,18 +38,14 @@ export function prepareInvalidations(invalidationPaths: string[]) {
   //    If true then remove the path
   multiPaths = multiPaths
     .sort((a, b) => b.length - a.length)
-    .filter((multiPath, index, array) => {
+    .filter((multiPath, _, array) =>
       // Search for a shorter string that is a substring multiPath
-      for (let i = index + 1; i < array.length; i++) {
+      !array.find((element) => {
         // Cut the tailing `*`
-        const pathWithoutTail = array[i].substr(0, array[i].length - 1);
-        if (multiPath.startsWith(pathWithoutTail)) {
-          return false;
-        }
-      }
-
-      return true;
-    });
+        const pathWithoutTail = element.substr(0, element.length - 1);
+        return multiPath.startsWith(pathWithoutTail);
+      })
+    );
 
   // Check if regular paths are already caught by a multiPath
   singlePaths = singlePaths.filter((singlePath) => {
@@ -81,7 +77,7 @@ export function createInvalidationChunk(
   singlePaths: string[],
   maxMultiPaths: number,
   maxTotalPaths: number
-) {
+): [string[], string[], string[]] {
   let pathsChunk: string[] = [];
   let newSinglePaths: string[] = singlePaths;
   let newMultiPaths: string[] = multiPaths;

--- a/packages/deploy-trigger/src/create-invalidation.ts
+++ b/packages/deploy-trigger/src/create-invalidation.ts
@@ -38,14 +38,21 @@ export function prepareInvalidations(invalidationPaths: string[]): [string[], st
   //    If true then remove the path
   multiPaths = multiPaths
     .sort((a, b) => b.length - a.length)
-    .filter((multiPath, _, array) =>
+    .filter((multiPath, index, array) => {
       // Search for a shorter string that is a substring multiPath
-      !array.find((element) => {
-        // Cut the tailing `*`
-        const pathWithoutTail = element.substr(0, element.length - 1);
-        return multiPath.startsWith(pathWithoutTail);
-      })
-    );
+      for (let i = index + 1; i < array.length; i++) {
+        const element = array[i];
+
+        if (element) {
+          const pathWithoutTail = element.substr(0, element.length - 1);
+          if (multiPath.startsWith(pathWithoutTail)) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    });
 
   // Check if regular paths are already caught by a multiPath
   singlePaths = singlePaths.filter((singlePath) => {

--- a/packages/deploy-trigger/src/deploy-trigger.ts
+++ b/packages/deploy-trigger/src/deploy-trigger.ts
@@ -39,7 +39,6 @@ export async function deployTrigger({
   deployBucket,
   versionId,
 }: Props): Promise<Response> {
-  let buildId = '';
   const params = {
     Key: key,
     Bucket: sourceBucket,
@@ -50,15 +49,11 @@ export async function deployTrigger({
   // If none is present, create a random id
   const zipHeaders = await s3.headObject(params).promise();
 
-  if (zipHeaders.Metadata && BuildIdMetaDataKey in zipHeaders.Metadata) {
-    buildId = zipHeaders.Metadata[BuildIdMetaDataKey]!;
-  } else if (zipHeaders.ETag) {
+  const buildId = zipHeaders.Metadata?.[BuildIdMetaDataKey] ??
     // Fallback 1: If no metadata is present, use the etag
-    buildId = zipHeaders.ETag;
-  } else {
+    zipHeaders.ETag ??
     // Fallback 2: If no metadata or etag is present, create random id
-    buildId = generateRandomBuildId();
-  }
+    generateRandomBuildId();
 
   // Get the object that triggered the event
   const zip = s3

--- a/packages/deploy-trigger/src/deploy-trigger.ts
+++ b/packages/deploy-trigger/src/deploy-trigger.ts
@@ -51,7 +51,7 @@ export async function deployTrigger({
   const zipHeaders = await s3.headObject(params).promise();
 
   if (zipHeaders.Metadata && BuildIdMetaDataKey in zipHeaders.Metadata) {
-    buildId = zipHeaders.Metadata[BuildIdMetaDataKey];
+    buildId = zipHeaders.Metadata[BuildIdMetaDataKey]!;
   } else if (zipHeaders.ETag) {
     // Fallback 1: If no metadata is present, use the etag
     buildId = zipHeaders.ETag;

--- a/packages/deploy-trigger/src/handler.ts
+++ b/packages/deploy-trigger/src/handler.ts
@@ -78,7 +78,7 @@ async function createCloudFrontInvalidation(
         InvalidationBatch,
       })
       .promise();
-  } catch (err) {
+  } catch (err: any) {
     console.log(err);
     if (err.code === 'TooManyInvalidationsInProgress') {
       // Send the invalidation back to the queue

--- a/packages/deploy-trigger/src/update-manifest.ts
+++ b/packages/deploy-trigger/src/update-manifest.ts
@@ -183,7 +183,8 @@ export async function updateManifest({
       continue;
     }
 
-    const file = manifestFiles[fileKey];
+    // We know the file exists because of the check above
+    const file = manifestFiles[fileKey]!;
     let isDeleted = false;
 
     // Get the files that can be expired

--- a/packages/node-bridge/src/bridge.ts
+++ b/packages/node-bridge/src/bridge.ts
@@ -272,7 +272,7 @@ export class Bridge {
         }
         try {
           req.setHeader(name, value);
-        } catch (err) {
+        } catch (err: any) {
           console.error(
             'Skipping HTTP request header: %j',
             `${name}: ${value}`

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -94,7 +94,7 @@ export class Proxy {
        *
        */
 
-      const routeConfig = this.routes[routeIndex];
+      const routeConfig = this.routes[routeIndex]!;
 
       //////////////////////////////////////////////////////////////////////////
       // Phase 1: Check for handler
@@ -162,8 +162,10 @@ export class Proxy {
         if (headers) {
           for (const originalKey in headers) {
             const originalValue = headers[originalKey];
-            const value = resolveRouteParameters(originalValue, match, keys);
-            combinedHeaders[originalKey] = value;
+            if (originalValue) {
+              const value = resolveRouteParameters(originalValue, match, keys);
+              combinedHeaders[originalKey] = value;
+            }
           }
         }
 

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -162,7 +162,7 @@ export class Proxy {
         if (headers) {
           for (const originalKey in headers) {
             const originalValue = headers[originalKey];
-            if (originalValue) {
+            if (originalValue !== undefined) {
               const value = resolveRouteParameters(originalValue, match, keys);
               combinedHeaders[originalKey] = value;
             }

--- a/packages/proxy/src/types.ts
+++ b/packages/proxy/src/types.ts
@@ -8,6 +8,7 @@ export interface ProxyConfig {
   lambdaRoutes: string[];
   staticRoutes: string[];
   prerenders: Record<string, { lambda: string }>;
+  apiId?: string;
 }
 
 export interface RouteResult {

--- a/packages/proxy/src/util/fetch-timeout.ts
+++ b/packages/proxy/src/util/fetch-timeout.ts
@@ -18,7 +18,7 @@ export async function fetchTimeout(timeout: number, url: string) {
 
   try {
     fetchResponse = await fetch(url, { signal: controller.signal });
-  } catch (err) {
+  } catch (err: any) {
     if (err.name === 'AbortError') {
       error = new Error(`Timeout while fetching config from ${url}`);
     } else {

--- a/packages/tf-next/.gitignore
+++ b/packages/tf-next/.gitignore
@@ -1,1 +1,2 @@
 dist
+terraform.config.json

--- a/packages/tf-next/package.json
+++ b/packages/tf-next/package.json
@@ -29,6 +29,7 @@
     "find-yarn-workspace-root": "^2.0.0",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",
+    "jsonpath": "^1.1.1",
     "tmp": "^0.2.1",
     "yargs": "^15.3.1"
   },
@@ -36,6 +37,7 @@
     "@types/archiver": "^5.1.0",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.2",
+    "@types/jsonpath": "^0.2.0",
     "@types/tmp": "^0.2.0",
     "@types/yargs": "^15.0.5"
   },

--- a/packages/tf-next/package.json
+++ b/packages/tf-next/package.json
@@ -24,6 +24,8 @@
     "@vercel/frameworks": "^0.0.15",
     "@vercel/routing-utils": "^1.10.1",
     "archiver": "^5.3.0",
+    "aws-sdk": "*",
+    "cuid": "^2.1.8",
     "find-yarn-workspace-root": "^2.0.0",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",

--- a/packages/tf-next/src/commands/create-deployment.ts
+++ b/packages/tf-next/src/commands/create-deployment.ts
@@ -113,22 +113,22 @@ async function createLambdas(
   }
 
   for (const key in lambdaConfigurations) {
-    const fileContent = await promises.readFile(path.join(configDir, lambdaConfigurations[key].filename));
+    const fileContent = await promises.readFile(path.join(configDir, lambdaConfigurations[key]!.filename));
     const createdLambda = await lambda.createFunction({
       Code: {
         ZipFile: fileContent,
       },
       FunctionName: `${key}-${deploymentId}`,
-      Role: roleArns[key],
+      Role: roleArns[key]!, // We know this exists because we created it in `createIAM`
       Description: 'Managed by Terraform-next.js',
       Environment: {
         Variables: existingFunction[0].values.environment[0].variables,
       },
-      Handler: lambdaConfigurations[key].handler || '',
-      MemorySize: lambdaConfigurations[key].memory || defaultFunctionMemory,
+      Handler: lambdaConfigurations[key]?.handler || '',
+      MemorySize: lambdaConfigurations[key]?.memory || defaultFunctionMemory,
       PackageType: 'Zip', // Default in TF
       Publish: false, // Default in TF
-      Runtime: lambdaConfigurations[key].runtime || defaultRuntime,
+      Runtime: lambdaConfigurations[key]?.runtime || defaultRuntime,
       Tags: {}, // TODO
       Timeout: lambdaTimeout,
       VpcConfig: {}, // TODO: Should get this from somewhere
@@ -199,7 +199,7 @@ async function createAPIGateway(
 
     await apiGatewayV2.createRoute({
       ApiId: api.ApiId,
-      RouteKey: `ANY ${lambdaConfigurations[key].route}/{proxy+}`,
+      RouteKey: `ANY ${lambdaConfigurations[key]?.route}/{proxy+}`,
       AuthorizationType: 'NONE', // TODO
       Target: `integrations/${integration.IntegrationId}`,
     }).promise();

--- a/packages/tf-next/src/commands/create-deployment.ts
+++ b/packages/tf-next/src/commands/create-deployment.ts
@@ -1,0 +1,79 @@
+import { ApiGatewayV2 } from 'aws-sdk';
+import * as path from 'path';
+
+const apiGatewayV2 = new ApiGatewayV2()
+
+interface CreateDeploymentProps {
+  id: string;
+  logLevel?: 'verbose' | 'none';
+  cwd: string;
+  target?: 'AWS';
+}
+
+interface LambdaConfiguration {
+  handler: string;
+  runtime: string;
+  filename: string;
+  route: string;
+}
+
+async function createDeploymentCommand({
+  id,
+  logLevel,
+  cwd,
+  target = 'AWS',
+}: CreateDeploymentProps) {
+  // TODO:
+  //    make lambdaTimeout configurable
+  //    make deploymentName configurable
+  //    allow tags to be passed through
+
+  const lambdaTimeout = 10;
+  const deploymentName = 'tf-next';
+
+  const configFilePath = path.join(cwd, '.next-tf', 'config.json');
+  const configFile = require(configFilePath);
+  const lambdas = configFile.lambdas;
+
+  const integrationKeys = lambdas.values().map((value: LambdaConfiguration) => {
+    return `ANY ${value.route}/{proxy+}`;
+  });
+  const integrationValues = lambdas.keys().map((key: string) => ({
+    lambda_arn:             'abc', // aws_lambda_function.this[integration_key].arn,
+    payload_format_version: '2.0',
+    timeout_milliseconds:   lambdaTimeout * 1000,
+  }));
+
+  // "lambdas": {
+  //   "__NEXT_API_LAMBDA_0": {
+  //     "handler": "now__launcher.launcher",
+  //     "runtime": "nodejs14.x",
+  //     "filename": "lambdas/__NEXT_API_LAMBDA_0.zip",
+  //     "route": "/__NEXT_API_LAMBDA_0"
+  //   },
+  //   "__NEXT_PAGE_LAMBDA_0": {
+  //     "handler": "now__launcher.launcher",
+  //     "runtime": "nodejs14.x",
+  //     "filename": "lambdas/__NEXT_PAGE_LAMBDA_0.zip",
+  //     "route": "/__NEXT_PAGE_LAMBDA_0"
+  //   }
+  // },
+
+  // Create lambdas
+  // Create API Gateway
+
+  await apiGatewayV2.createApi({
+    Name: `${deploymentName} - ${id}`,
+    ProtocolType: 'HTTP',
+    ApiKeySelectionExpression: '$request.header.x-api-key',
+    Description: 'Managed by Terraform-next.js',
+    RouteSelectionExpression: '$request.method $request.path',
+    Tags: {},
+  }).promise();
+
+  // Modify proxy config to include API Gateway id
+  // Upload proxy config to bucket
+  // Upload static assets
+}
+
+export default createDeploymentCommand;

--- a/packages/tf-next/src/commands/create-deployment.ts
+++ b/packages/tf-next/src/commands/create-deployment.ts
@@ -1,69 +1,184 @@
-import { ApiGatewayV2 } from 'aws-sdk';
+import { ApiGatewayV2, CloudWatchLogs, IAM, Lambda } from 'aws-sdk';
+import { promises } from 'fs';
+import { query } from 'jsonpath';
 import * as path from 'path';
+import { inspect } from 'util';
 
-const apiGatewayV2 = new ApiGatewayV2()
+const apiGatewayV2 = new ApiGatewayV2();
+const cloudWatch = new CloudWatchLogs();
+const iam = new IAM();
+const lambda = new Lambda();
+
+// "lambdas": {
+//   "__NEXT_API_LAMBDA_0": {
+//     "handler": "now__launcher.launcher",
+//     "runtime": "nodejs14.x",
+//     "filename": "lambdas/__NEXT_API_LAMBDA_0.zip",
+//     "route": "/__NEXT_API_LAMBDA_0"
+//   },
+//   "__NEXT_PAGE_LAMBDA_0": {
+//     "handler": "now__launcher.launcher",
+//     "runtime": "nodejs14.x",
+//     "filename": "lambdas/__NEXT_PAGE_LAMBDA_0.zip",
+//     "route": "/__NEXT_PAGE_LAMBDA_0"
+//   }
+// },
+
+type LogLevel = 'verbose' | 'none' | undefined;
 
 interface CreateDeploymentProps {
-  id: string;
-  logLevel?: 'verbose' | 'none';
+  deploymentId: string;
+  logLevel: LogLevel;
   cwd: string;
+  terraformState: any;
   target?: 'AWS';
 }
+
+type LambdaConfigurations = {[key: string]: LambdaConfiguration};
 
 interface LambdaConfiguration {
   handler: string;
   runtime: string;
   filename: string;
   route: string;
+  memory?: number;
 }
 
-async function createDeploymentCommand({
-  id,
-  logLevel,
-  cwd,
-  target = 'AWS',
-}: CreateDeploymentProps) {
-  // TODO:
-  //    make lambdaTimeout configurable
-  //    make deploymentName configurable
-  //    allow tags to be passed through
+type LambdaArns = {[key: string]: string};
+type RoleArns = {[key: string]: string};
 
-  const lambdaTimeout = 10;
-  const deploymentName = 'tf-next';
+const assumeRolePolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}`;
 
-  const configFilePath = path.join(cwd, '.next-tf', 'config.json');
-  const configFile = require(configFilePath);
-  const lambdas = configFile.lambdas;
+async function createIAM(
+  deploymentId: string,
+  lambdaConfigurations: LambdaConfigurations,
+  terraformState: any,
+): Promise<RoleArns> {
+  const roleArns: RoleArns = {};
 
-  const integrationKeys = lambdas.values().map((value: LambdaConfiguration) => {
-    return `ANY ${value.route}/{proxy+}`;
-  });
-  const integrationValues = lambdas.keys().map((key: string) => ({
-    lambda_arn:             'abc', // aws_lambda_function.this[integration_key].arn,
-    payload_format_version: '2.0',
-    timeout_milliseconds:   lambdaTimeout * 1000,
-  }));
+  const lambdaLoggingPolicy = query(terraformState, '$..*[?(@.type=="aws_iam_policy" && @.name=="lambda_logging")]');
+  if (lambdaLoggingPolicy.length === 0) {
+    throw new Error('Please first run `terraform apply` before trying to create deployments via `tf-next create-deployment`.');
+  }
 
-  // "lambdas": {
-  //   "__NEXT_API_LAMBDA_0": {
-  //     "handler": "now__launcher.launcher",
-  //     "runtime": "nodejs14.x",
-  //     "filename": "lambdas/__NEXT_API_LAMBDA_0.zip",
-  //     "route": "/__NEXT_API_LAMBDA_0"
-  //   },
-  //   "__NEXT_PAGE_LAMBDA_0": {
-  //     "handler": "now__launcher.launcher",
-  //     "runtime": "nodejs14.x",
-  //     "filename": "lambdas/__NEXT_PAGE_LAMBDA_0.zip",
-  //     "route": "/__NEXT_PAGE_LAMBDA_0"
-  //   }
-  // },
+  for (const key in lambdaConfigurations) {
+    const functionName = `${key}-${deploymentId}`;
 
-  // Create lambdas
-  // Create API Gateway
+    // TODO: Handle lambda_role_permissions_boundary
+    const role = await iam.createRole({
+      AssumeRolePolicyDocument: assumeRolePolicy,
+      RoleName: functionName,
+      Description: 'Managed by Terraform Next.js',
+      Tags: [], // TODO
+    }).promise();
+    roleArns[key] = role.Role.Arn;
+
+    const logGroupName = `/aws/lambda/${functionName}`;
+
+    await cloudWatch.createLogGroup({
+      logGroupName,
+      // TODO: tags: {},
+    }).promise();
+
+    await cloudWatch.putRetentionPolicy({
+      logGroupName,
+      retentionInDays: 14,
+    }).promise();
+
+    await iam.attachRolePolicy({
+      PolicyArn: lambdaLoggingPolicy[0].values.arn,
+      RoleName: functionName,
+    }).promise();
+  }
+
+  return roleArns;
+}
+
+async function createLambdas(
+  deploymentId: string,
+  configDir: string,
+  defaultRuntime: string,
+  defaultFunctionMemory: number,
+  lambdaTimeout: number,
+  lambdaConfigurations: LambdaConfigurations,
+  roleArns: RoleArns,
+): Promise<LambdaArns> {
+  const arns: LambdaArns = {};
+
+  // TODO: Do we ever need to update existing functions, or do we just always create new ones?
+
+  for (const key in lambdaConfigurations) {
+    const fileContent = await promises.readFile(path.join(configDir, lambdaConfigurations[key].filename));
+    const createdLambda = await lambda.createFunction({
+      Code: {
+        ZipFile: fileContent,
+      },
+      FunctionName: `${key}-${deploymentId}`,
+      Role: roleArns[key],
+      Description: 'Managed by Terraform-next.js',
+      Environment: {
+        Variables: {}, // TODO: Should get this from somewhere
+      },
+      Handler: lambdaConfigurations[key].handler || '',
+      MemorySize: lambdaConfigurations[key].memory || defaultFunctionMemory,
+      PackageType: 'Zip', // Default in TF
+      Publish: false, // Default in TF
+      Runtime: lambdaConfigurations[key].runtime || defaultRuntime,
+      Tags: {}, // TODO
+      Timeout: lambdaTimeout,
+      VpcConfig: {}, // TODO: Should get this from somewhere
+      //   dynamic "vpc_config" {
+      //     for_each = var.lambda_attach_to_vpc ? [true] : []
+      //     content {
+      //       security_group_ids = var.vpc_security_group_ids
+      //       subnet_ids         = var.vpc_subnet_ids
+      //     }
+      //   }
+    }).promise();
+
+    if (createdLambda.FunctionArn) {
+      arns[key] = createdLambda.FunctionArn;
+    } else {
+      throw new Error(`Created lambda does not have arn: ${inspect(createdLambda)}`);
+    }
+  }
+
+  return arns;
+}
+
+async function createAPIGateway(
+  deploymentId: string,
+  deploymentName: string,
+  lambdaTimeout: number,
+  lambdaConfigurations: LambdaConfigurations,
+  lambdaArns: LambdaArns,
+) {
+  const integrationKeys = [];
+  const integrationValues = [];
+
+  for (const key in lambdaConfigurations) {
+    integrationKeys.push(`ANY ${lambdaConfigurations[key].route}/{proxy+}`)
+    integrationValues.push({
+      lambda_arn:             lambdaArns[key],
+      payload_format_version: '2.0',
+      timeout_milliseconds:   lambdaTimeout * 1000,
+    });
+  }
 
   await apiGatewayV2.createApi({
-    Name: `${deploymentName} - ${id}`,
+    Name: `${deploymentName} - ${deploymentId}`,
     ProtocolType: 'HTTP',
     ApiKeySelectionExpression: '$request.header.x-api-key',
     Description: 'Managed by Terraform-next.js',
@@ -71,6 +186,195 @@ async function createDeploymentCommand({
     Tags: {},
   }).promise();
 
+  // resource "aws_apigatewayv2_stage" "default" {
+  //   count = var.create && var.create_default_stage ? 1 : 0
+
+  //   api_id      = aws_apigatewayv2_api.this[0].id
+  //   name        = "$default"
+  //   auto_deploy = true
+
+  //   dynamic "access_log_settings" {
+  //     for_each = var.default_stage_access_log_destination_arn != null && var.default_stage_access_log_format != null ? [true] : []
+  //     content {
+  //       destination_arn = var.default_stage_access_log_destination_arn
+  //       format          = var.default_stage_access_log_format
+  //     }
+  //   }
+
+  //   dynamic "default_route_settings" {
+  //     for_each = length(keys(var.default_route_settings)) == 0 ? [] : [var.default_route_settings]
+  //     content {
+  //       data_trace_enabled       = lookup(default_route_settings.value, "data_trace_enabled", false)
+  //       detailed_metrics_enabled = lookup(default_route_settings.value, "detailed_metrics_enabled", false)
+  //       logging_level            = lookup(default_route_settings.value, "logging_level", null)
+  //       throttling_burst_limit   = lookup(default_route_settings.value, "throttling_burst_limit", null)
+  //       throttling_rate_limit    = lookup(default_route_settings.value, "throttling_rate_limit", null)
+  //     }
+  //   }
+
+  //   #  # bug - https://github.com/terraform-providers/terraform-provider-aws/issues/12893
+  //   #  dynamic "route_settings" {
+  //   #    for_each = var.create_routes_and_integrations ? var.integrations : {}
+  //   #    content {
+  //   #      route_key = route_settings.key
+  //   #      data_trace_enabled = lookup(route_settings.value, "data_trace_enabled", null)
+  //   #      detailed_metrics_enabled         = lookup(route_settings.value, "detailed_metrics_enabled", null)
+  //   #      logging_level         = lookup(route_settings.value, "logging_level", null)  # Error: error updating API Gateway v2 stage ($default): BadRequestException: Execution logs are not supported on protocolType HTTP
+  //   #      throttling_burst_limit         = lookup(route_settings.value, "throttling_burst_limit", null)
+  //   #      throttling_rate_limit         = lookup(route_settings.value, "throttling_rate_limit", null)
+  //   #    }
+  //   #  }
+
+  //   tags = merge(var.default_stage_tags, var.tags)
+
+  //   # Bug in terraform-aws-provider with perpetual diff
+  //   lifecycle {
+  //     ignore_changes = [deployment_id]
+  //   }
+  // }
+
+  // resource "aws_apigatewayv2_route" "this" {
+  //   for_each = var.create && var.create_routes_and_integrations ? var.integrations : {}
+
+  //   api_id    = aws_apigatewayv2_api.this[0].id
+  //   route_key = each.key
+
+  //   api_key_required                    = lookup(each.value, "api_key_required", null)
+  //   authorization_type                  = lookup(each.value, "authorization_type", "NONE")
+  //   authorizer_id                       = lookup(each.value, "authorizer_id", null)
+  //   model_selection_expression          = lookup(each.value, "model_selection_expression", null)
+  //   operation_name                      = lookup(each.value, "operation_name", null)
+  //   route_response_selection_expression = lookup(each.value, "route_response_selection_expression", null)
+  //   target                              = "integrations/${aws_apigatewayv2_integration.this[each.key].id}"
+
+  //   # Not sure what structure is allowed for these arguments...
+  //   #  authorization_scopes = lookup(each.value, "authorization_scopes", null)
+  //   #  request_models  = lookup(each.value, "request_models", null)
+  // }
+
+  // resource "aws_apigatewayv2_integration" "this" {
+  //   for_each = var.create && var.create_routes_and_integrations ? var.integrations : {}
+
+  //   api_id      = aws_apigatewayv2_api.this[0].id
+  //   description = lookup(each.value, "description", null)
+
+  //   integration_type    = lookup(each.value, "integration_type", lookup(each.value, "lambda_arn", "") != "" ? "AWS_PROXY" : "MOCK")
+  //   integration_subtype = lookup(each.value, "integration_subtype", null)
+  //   integration_method  = lookup(each.value, "integration_method", lookup(each.value, "integration_subtype", null) == null ? "POST" : null)
+  //   integration_uri     = lookup(each.value, "lambda_arn", lookup(each.value, "integration_uri", null))
+
+  //   connection_type = lookup(each.value, "connection_type", "INTERNET")
+  //   connection_id   = try(aws_apigatewayv2_vpc_link.this[each.value["vpc_link"]].id, lookup(each.value, "connection_id", null))
+
+  //   payload_format_version    = lookup(each.value, "payload_format_version", null)
+  //   timeout_milliseconds      = lookup(each.value, "timeout_milliseconds", null)
+  //   passthrough_behavior      = lookup(each.value, "passthrough_behavior", null)
+  //   content_handling_strategy = lookup(each.value, "content_handling_strategy", null)
+  //   credentials_arn           = lookup(each.value, "credentials_arn", null)
+  //   request_parameters        = try(jsondecode(each.value["request_parameters"]), each.value["request_parameters"], null)
+
+  //   dynamic "tls_config" {
+  //     for_each = flatten([try(jsondecode(each.value["tls_config"]), each.value["tls_config"], [])])
+  //     content {
+  //       server_name_to_verify = tls_config.value["server_name_to_verify"]
+  //     }
+  //   }
+  // }
+
+  // # VPC Link (Private API)
+  // resource "aws_apigatewayv2_vpc_link" "this" {
+  //   for_each = var.create && var.create_vpc_link ? var.vpc_links : {}
+
+  //   name               = lookup(each.value, "name", each.key)
+  //   security_group_ids = each.value["security_group_ids"]
+  //   subnet_ids         = each.value["subnet_ids"]
+
+  //   tags = merge(var.tags, var.vpc_link_tags, lookup(each.value, "tags", {}))
+  // }
+
+  // TODO: create integrations
+}
+
+async function createLambdaPermissions() {
+  // resource "aws_lambda_permission" "current_version_triggers" {
+  //   for_each = local.lambdas
+
+  //   statement_id  = "AllowInvokeFromApiGateway"
+  //   action        = "lambda:InvokeFunction"
+  //   function_name = random_id.function_name[each.key].hex
+  //   principal     = "apigateway.amazonaws.com"
+
+  //   source_arn = "${module.api_gateway.apigatewayv2_api_execution_arn}/*/*/*"
+  // }
+}
+
+function log(deploymentId: string, message: string, logLevel: LogLevel) {
+  if (logLevel === 'verbose') {
+    console.log(`Deployment ${deploymentId}: created log groups and roles.`);
+  }
+
+}
+async function createDeploymentCommand({
+  deploymentId,
+  logLevel,
+  cwd,
+  terraformState,
+  target = 'AWS',
+}: CreateDeploymentProps) {
+  // TODO:
+  //    make lambdaTimeout configurable
+  //    make deploymentName configurable
+  //    make defaultRuntime configurable
+  //    allow tags to be passed through
+
+  const lambdaTimeout = 10;
+  const deploymentName = 'tf-next';
+  const defaultRuntime = 'nodejs14.x';
+  const defaultFunctionMemory = 1024;
+
+  const configDir = path.join(cwd, '.next-tf');
+  const configFile = require(path.join(configDir, 'config.json'));
+  const lambdaConfigurations = configFile.lambdas;
+
+  // Create log groups
+  const roleArns = await createIAM(
+    deploymentId,
+    lambdaConfigurations,
+    terraformState,
+  );
+
+  log(deploymentId, 'created log groups and roles.', logLevel);
+
+  // Create lambdas
+  const lambdaArns = await createLambdas(
+    deploymentId,
+    configDir,
+    defaultRuntime,
+    defaultFunctionMemory,
+    lambdaTimeout,
+    lambdaConfigurations,
+    roleArns,
+  );
+
+  log(deploymentId, 'created lambda functions.', logLevel);
+
+  // Create API Gateway
+  await createAPIGateway(
+    deploymentId,
+    deploymentName,
+    lambdaTimeout,
+    lambdaConfigurations,
+    lambdaArns,
+  );
+
+  log(deploymentId, 'created API gateway.', logLevel);
+
+  // Create lambda permissions
+  await createLambdaPermissions();
+
+  log(deploymentId, 'created lambda permissions.', logLevel);
+
+  // Image optimizer stuff
   // Modify proxy config to include API Gateway id
   // Upload proxy config to bucket
   // Upload static assets

--- a/packages/tf-next/src/commands/delete-deployment.ts
+++ b/packages/tf-next/src/commands/delete-deployment.ts
@@ -1,0 +1,156 @@
+import { ApiGatewayV2, CloudWatchLogs, IAM, Lambda } from 'aws-sdk';
+import { query } from 'jsonpath';
+import * as path from 'path';
+
+const apiGatewayV2 = new ApiGatewayV2();
+const cloudWatch = new CloudWatchLogs();
+const iam = new IAM();
+const lambda = new Lambda();
+
+type LogLevel = 'verbose' | 'none' | undefined;
+
+interface DeleteDeploymentProps {
+  deploymentId: string;
+  logLevel: LogLevel;
+  cwd: string;
+  terraformState: any;
+  target?: 'AWS';
+}
+
+type LambdaConfigurations = {[key: string]: LambdaConfiguration};
+
+interface LambdaConfiguration {
+  handler: string;
+  runtime: string;
+  filename: string;
+  route: string;
+  memory?: number;
+}
+
+async function deleteIAM(
+  deploymentId: string,
+  lambdaConfigurations: LambdaConfigurations,
+  terraformState: any,
+) {
+  const lambdaLoggingPolicy = query(terraformState, '$..*[?(@.type=="aws_iam_policy" && @.name=="lambda_logging")]');
+  if (lambdaLoggingPolicy.length === 0) {
+    throw new Error('Please first run `terraform apply` before trying to create deployments via `tf-next create-deployment`.');
+  }
+
+  for (const key in lambdaConfigurations) {
+    const functionName = `${key}-${deploymentId}`;
+    const logGroupName = `/aws/lambda/${functionName}`;
+
+    await cloudWatch.deleteLogGroup({
+      logGroupName,
+    }).promise();
+
+    await iam.detachRolePolicy({
+      PolicyArn: lambdaLoggingPolicy[0].values.arn,
+      RoleName: functionName,
+    }).promise();
+
+    await iam.deleteRole({
+      RoleName: functionName,
+    }).promise();
+  }
+}
+
+async function deleteLambdas(
+  deploymentId: string,
+  lambdaConfigurations: LambdaConfigurations,
+) {
+  for (const key in lambdaConfigurations) {
+    await lambda.deleteFunction({
+      FunctionName: `${key}-${deploymentId}`,
+    }).promise();
+  }
+}
+
+async function deleteAPIGateway(
+  deploymentId: string,
+  deploymentName: string,
+) {
+  const apis = await apiGatewayV2.getApis({}).promise();
+  const api = (apis.Items || []).find((api) => api.Name === `${deploymentName} - ${deploymentId}`);
+  if (api && api.ApiId) {
+    await apiGatewayV2.deleteApi({
+      ApiId: api.ApiId,
+    }).promise();
+  }
+}
+
+async function deleteLambdaPermissions(
+  deploymentId: string,
+  lambdaConfigurations: LambdaConfigurations,
+) {
+  for (const key in lambdaConfigurations) {
+    await lambda.removePermission({
+      FunctionName: `${key}-${deploymentId}`,
+      StatementId: 'AllowInvokeFromApiGateway',
+    }).promise();
+  }
+}
+
+function log(deploymentId: string, message: string, logLevel: LogLevel) {
+  if (logLevel === 'verbose') {
+    console.log(`Deployment ${deploymentId}: ${message}`);
+  }
+}
+
+async function deleteDeploymentCommand({
+  deploymentId,
+  logLevel,
+  cwd,
+  terraformState,
+  target = 'AWS',
+}: DeleteDeploymentProps) {
+  const configDir = path.join(cwd, '.next-tf');
+  const configFile = require(path.join(configDir, 'config.json'));
+  const lambdaConfigurations = configFile.lambdas;
+  const deploymentName = 'tf-next';
+
+  // Delete lambda permissions
+  await deleteLambdaPermissions(
+    deploymentId,
+    lambdaConfigurations,
+  );
+
+  log(deploymentId, 'deleted lambda permissions.', logLevel);
+
+  // Delete API Gateway
+  await deleteAPIGateway(
+    deploymentId,
+    deploymentName,
+  );
+
+  log(deploymentId, 'deleted API gateway.', logLevel);
+
+  // Delete lambdas
+  await deleteLambdas(
+    deploymentId,
+    lambdaConfigurations,
+  );
+
+  log(deploymentId, 'deleted lambda functions.', logLevel);
+
+  // Delete IAM & CW resources
+  await deleteIAM(
+    deploymentId,
+    lambdaConfigurations,
+    terraformState,
+  );
+
+  log(deploymentId, 'deleted log groups and roles.', logLevel);
+
+
+
+
+
+  // Image optimizer stuff
+  // Modify proxy config to include API Gateway id
+  // Upload proxy config to bucket
+  // Upload static assets
+}
+
+export default deleteDeploymentCommand;

--- a/packages/tf-next/src/commands/list-deployments.ts
+++ b/packages/tf-next/src/commands/list-deployments.ts
@@ -1,0 +1,20 @@
+import { ApiGatewayV2 } from 'aws-sdk';
+
+const apiGatewayV2 = new ApiGatewayV2();
+
+interface ListDeploymentProps {
+  target?: 'AWS';
+}
+
+async function listDeploymentsCommand({
+  target = 'AWS',
+}: ListDeploymentProps) {
+  const apis = await apiGatewayV2.getApis().promise();
+  for (const item of apis.Items || []) {
+    if (item.Name.startsWith('tf-next')) {
+      console.log(`${item.Name} - ${item.ApiId} - ${item.Description}`);
+    }
+  }
+}
+
+export default listDeploymentsCommand;

--- a/packages/tf-next/src/commands/list-deployments.ts
+++ b/packages/tf-next/src/commands/list-deployments.ts
@@ -12,7 +12,10 @@ async function listDeploymentsCommand({
   const apis = await apiGatewayV2.getApis().promise();
   for (const item of apis.Items || []) {
     if (item.Name.startsWith('tf-next') && item.Description === 'Managed by Terraform-next.js') {
-      console.log(item.ApiId);
+      const name = item.Name.split(' - ');
+      if (name[name.length - 1] !== 'tf-next') {
+        console.log(name[name.length - 1]);
+      }
     }
   }
 }

--- a/packages/tf-next/src/commands/list-deployments.ts
+++ b/packages/tf-next/src/commands/list-deployments.ts
@@ -11,8 +11,8 @@ async function listDeploymentsCommand({
 }: ListDeploymentProps) {
   const apis = await apiGatewayV2.getApis().promise();
   for (const item of apis.Items || []) {
-    if (item.Name.startsWith('tf-next')) {
-      console.log(`${item.Name} - ${item.ApiId} - ${item.Description}`);
+    if (item.Name.startsWith('tf-next') && item.Description === 'Managed by Terraform-next.js') {
+      console.log(item.ApiId);
     }
   }
 }

--- a/packages/tf-next/src/index.ts
+++ b/packages/tf-next/src/index.ts
@@ -1,6 +1,8 @@
 import cuid from 'cuid';
 import yargs from 'yargs';
 
+// TODO: Have a central configuration for AWS API versions
+
 yargs
   .scriptName('tf-next')
   .usage('$0 <cmd> [args]')
@@ -47,12 +49,21 @@ yargs
     },
     async ({ verbose }) => {
       const cwd = process.cwd();
-      const id = cuid();
+      const deploymentId = cuid();
+
+      // TODO:
+      // Figure out a good way to pass the current terraform state. Especially
+      // considering that there could be multiple environments (preview,
+      // production). For development/testing, we'll save the current state,
+      // that we get when running `$ terraform show -json` into a file called
+      // `terraform.config.json` at the root of this package.
+      const terraformState = require('../terraform.config.json');
 
       (await import('./commands/create-deployment')).default({
-        id,
+        deploymentId,
         logLevel: verbose ? 'verbose' : 'none',
         cwd,
+        terraformState,
       });
     }
   )

--- a/packages/tf-next/src/index.ts
+++ b/packages/tf-next/src/index.ts
@@ -2,6 +2,8 @@ import cuid from 'cuid';
 import yargs from 'yargs';
 
 // TODO: Have a central configuration for AWS API versions
+// TODO: Handle trying to delete a deployment that doesn't exist
+// TODO: Handle trying to create a deployment with an id that already exists
 
 yargs
   .scriptName('tf-next')
@@ -60,6 +62,40 @@ yargs
       const terraformState = require('../terraform.config.json');
 
       (await import('./commands/create-deployment')).default({
+        deploymentId,
+        logLevel: verbose ? 'verbose' : 'none',
+        cwd,
+        terraformState,
+      });
+    }
+  )
+  .command(
+    'delete-deployment',
+    'Delete an existing deployment',
+    (yargs_) => {
+      return yargs_
+        .option('deploymentId', {
+          type: 'string',
+          description: 'The id of the deployment to delete',
+          demandOption: true,
+        })
+        .option('verbose', {
+          type: 'boolean',
+          description: 'Run with verbose logging',
+        });
+    },
+    async ({ deploymentId, verbose }) => {
+      const cwd = process.cwd();
+
+      // TODO:
+      // Figure out a good way to pass the current terraform state. Especially
+      // considering that there could be multiple environments (preview,
+      // production). For development/testing, we'll save the current state,
+      // that we get when running `$ terraform show -json` into a file called
+      // `terraform.config.json` at the root of this package.
+      const terraformState = require('../terraform.config.json');
+
+      (await import('./commands/delete-deployment')).default({
         deploymentId,
         logLevel: verbose ? 'verbose' : 'none',
         cwd,

--- a/packages/tf-next/src/index.ts
+++ b/packages/tf-next/src/index.ts
@@ -1,26 +1,60 @@
+import cuid from 'cuid';
 import yargs from 'yargs';
 
-yargs.command(
-  'build',
-  'Build the next.js project',
-  (yargs_) => {
-    return yargs_
-      .option('skipDownload', {
-        type: 'boolean',
-        description: 'Runs the build in the current working directory',
-      })
-      .option('verbose', {
-        type: 'boolean',
-        description: 'Run with verbose logging',
-      });
-  },
-  async ({ skipDownload, verbose }) => {
-    const cwd = process.cwd();
+yargs
+  .scriptName('tf-next')
+  .usage('$0 <cmd> [args]')
+  .command(
+    'build',
+    'Build the next.js project',
+    (yargs_) => {
+      return yargs_
+        .option('skipDownload', {
+          type: 'boolean',
+          description: 'Runs the build in the current working directory',
+        })
+        .option('verbose', {
+          type: 'boolean',
+          description: 'Run with verbose logging',
+        });
+    },
+    async ({ skipDownload, verbose }) => {
+      const cwd = process.cwd();
 
-    (await import('./commands/build')).default({
-      skipDownload,
-      logLevel: verbose ? 'verbose' : 'none',
-      cwd,
-    });
-  }
-).argv;
+      (await import('./commands/build')).default({
+        skipDownload,
+        logLevel: verbose ? 'verbose' : 'none',
+        cwd,
+      });
+    }
+  )
+  .command(
+    'list-deployments',
+    'List existing deployments',
+    async () => {
+      (await import('./commands/list-deployments')).default({});
+    }
+  )
+  .command(
+    'create-deployment',
+    'Create a new deployment that runs in parallel to the existing deployments',
+    (yargs_) => {
+      return yargs_
+        .option('verbose', {
+          type: 'boolean',
+          description: 'Run with verbose logging',
+        });
+    },
+    async ({ verbose }) => {
+      const cwd = process.cwd();
+      const id = cuid();
+
+      (await import('./commands/create-deployment')).default({
+        id,
+        logLevel: verbose ? 'verbose' : 'none',
+        cwd,
+      });
+    }
+  )
+  .help()
+  .argv;

--- a/packages/tf-next/src/index.ts
+++ b/packages/tf-next/src/index.ts
@@ -61,12 +61,14 @@ yargs
       // `terraform.config.json` at the root of this package.
       const terraformState = require('../terraform.config.json');
 
-      (await import('./commands/create-deployment')).default({
+      await (await import('./commands/create-deployment')).default({
         deploymentId,
         logLevel: verbose ? 'verbose' : 'none',
         cwd,
         terraformState,
       });
+
+      console.log(`Created deployment ${deploymentId}.`)
     }
   )
   .command(
@@ -95,12 +97,14 @@ yargs
       // `terraform.config.json` at the root of this package.
       const terraformState = require('../terraform.config.json');
 
-      (await import('./commands/delete-deployment')).default({
+      await (await import('./commands/delete-deployment')).default({
         deploymentId,
         logLevel: verbose ? 'verbose' : 'none',
         cwd,
         terraformState,
       });
+
+      console.log(`Deleted deployment ${deploymentId}.`)
     }
   )
   .help()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "declaration": false,
     "sourceMap": false,
     "experimentalDecorators": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noUncheckedIndexedAccess": true
   },
   "exclude": ["node_modules", "examples/**/*"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -143,6 +143,15 @@ variable "tags" {
   default     = {}
 }
 
+#####################
+# Preview Deployments
+#####################
+variable "domain_name" {
+  description = "This is used to figure out which preview deployment to route to."
+  type        = string
+  default     = null
+}
+
 ################
 # Debug Settings
 ################

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,6 +834,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/jsonpath@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/jsonpath/-/jsonpath-0.2.0.tgz#13c62db22a34d9c411364fac79fd374d63445aa1"
+  integrity sha512-v7qlPA0VpKUlEdhghbDqRoKMxFB3h3Ch688TApBJ6v+XLDdvWCGLJIYiPKGZnS6MAOie+IorCfNYVHOPIHSWwQ==
+
 "@types/mime@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.2.tgz#857a118d8634c84bba7ae14088e4508490cd5da5"
@@ -2459,7 +2464,7 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escodegen@^1.14.1:
+escodegen@^1.14.1, escodegen@^1.8.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
   integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
@@ -2470,6 +2475,11 @@ escodegen@^1.14.1:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+esprima@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.2.2.tgz#76a0fd66fcfe154fd292667dc264019750b1657b"
+  integrity sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs=
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -4064,6 +4074,15 @@ jsonfile@^6.0.1:
     universalify "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonpath@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.1.1.tgz#0ca1ed8fb65bb3309248cc9d5466d12d5b0b9901"
+  integrity sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==
+  dependencies:
+    esprima "1.2.2"
+    static-eval "2.0.2"
+    underscore "1.12.1"
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -5743,6 +5762,13 @@ stacktrace-parser@0.1.10:
   dependencies:
     type-fest "^0.7.1"
 
+static-eval@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
+  integrity sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==
+  dependencies:
+    escodegen "^1.8.1"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -6254,6 +6280,11 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
+
+underscore@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
 union-value@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,6 +2156,11 @@ csv-parser@~1.8.0:
     minimist "^0.2.0"
     ndjson "^1.4.0"
 
+cuid@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.8.tgz#cbb88f954171e0d5747606c0139fb65c5101eac0"
+  integrity sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6266,10 +6266,10 @@ typescript@^4.1.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
-typescript@^4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This is the first PR in a series to introduce the handling of multiple parallel deployments. 

What this PR does:
* Create a deployment via `tf-next create-deployment` that adds log groups, lambdas, API gateway, proxy configuration
* Forward incoming requests to the correct deployment based on subdomain
* List and delete deployments

Things left to do:
* Handle image(s) (optimization)
* Handle static assets
* Handle VPCs
* Allow for things like tags, role boundaries, etc. to be passed on to the `create-deployment` command
* Remove code duplication (TF/TS)
* Build domain alias switching to allow pointing a (sub)domain to a specific deployment (rollback of production deployments)
* Documentation/an example of how to setup wildcard subdomains for this
* New architecture picture