### PR TITLE
Improve e2e tests for static files

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,49 @@ env:
   NEXT_TELEMETRY_DISABLED: 1
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: registry.gitlab.com/dealmore/dealmore-build-images/lambda:nodejs14.x
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            .yarn
+            **/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --cache-folder .yarn
+
+      - name: Build runtime
+        run: yarn @dealmore/tf-next-runtime build
+
+      - name: Build tf-next
+        run: yarn workspace tf-next build
+
+      - name: Build proxy
+        run: yarn @dealmore/terraform-next-proxy build
+
+      - name: Build deploy-trigger
+        run: yarn @dealmore/terraform-next-deploy-trigger build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: |
+            packages/runtime/dist/
+            packages/tf-next/dist/
+            packages/proxy/dist.zip
+            packages/deploy-trigger/dist.zip
+          if-no-files-found: error
+
   test-integration:
+    needs: build
     runs-on: ubuntu-latest
     container: registry.gitlab.com/dealmore/dealmore-build-images/lambda:nodejs14.x
     services:
@@ -39,13 +81,17 @@ jobs:
       - name: Yarn install
         run: yarn --frozen-lockfile --cache-folder .yarn
 
-      - name: Build runtime
-        run: yarn --cwd packages/runtime build
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: .
 
       - name: Jest
         run: yarn test
 
   test-e2e-prepare:
+    needs: build
     runs-on: ubuntu-latest
     container: registry.gitlab.com/dealmore/dealmore-build-images/lambda:nodejs14.x
     steps:
@@ -62,11 +108,11 @@ jobs:
       - name: Yarn install
         run: yarn --frozen-lockfile --cache-folder .yarn
 
-      - name: Build runtime
-        run: yarn --cwd packages/runtime build
-
-      - name: Build tf-next
-        run: yarn --cwd packages/tf-next build
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: .
 
       - name: Build e2e fixtures
         run: yarn test:e2e:prepare
@@ -75,13 +121,11 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: e2e-fixtures
-          path: |
-            packages/proxy/dist.zip
-            test/**/.next-tf/**/*
+          path: test/**/.next-tf/**/*
           if-no-files-found: error
 
   test-e2e:
-    needs: test-e2e-prepare
+    needs: [build, test-e2e-prepare]
     runs-on: ubuntu-latest
     env:
       SAM_CLI_TELEMETRY: 0
@@ -105,6 +149,12 @@ jobs:
             .yarn
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: .
 
       - name: Download prebuilt e2e fixtures
         uses: actions/download-artifact@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: e2e-fixtures
-          path: test/**/.next-tf/**/*
+          path: test/fixtures/**/.next-tf/**/*
           if-no-files-found: error
 
   test-e2e:
@@ -160,6 +160,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: e2e-fixtures
+          path: test/fixtures
 
       - name: Install dependencies
         run: yarn --frozen-lockfile --cache-folder .yarn

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: dist
-          path: .
+          path: packages
 
       - name: Jest
         run: yarn test
@@ -112,7 +112,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: dist
-          path: .
+          path: packages
 
       - name: Build e2e fixtures
         run: yarn test:e2e:prepare
@@ -154,7 +154,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: dist
-          path: .
+          path: packages
 
       - name: Download prebuilt e2e fixtures
         uses: actions/download-artifact@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -127,11 +127,20 @@ jobs:
   test-e2e:
     needs: [build, test-e2e-prepare]
     runs-on: ubuntu-latest
+    services:
+      s3:
+        image: registry.gitlab.com/dealmore/dealmore-build-images:s3-emulator
+        env:
+          MINIO_ACCESS_KEY: test
+          MINIO_SECRET_KEY: testtest
     env:
       SAM_CLI_TELEMETRY: 0
       # Don't worry these are fake AWS credentials for AWS SAM
       AWS_ACCESS_KEY_ID: ABIAZLJNBT8I3KFOU4NO
       AWS_SECRET_ACCESS_KEY: 4Xt3Rbx4DO21MhK1IHXZXRvVRDuqaQ0Wo5lILA/h
+      MINIO_ACCESS_KEY: test
+      MINIO_SECRET_KEY: testtest
+      S3_ENDPOINT: s3:9000
 
     steps:
       - name: Setup AWS SAM
@@ -148,7 +157,7 @@ jobs:
           path: |
             .yarn
             **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-e2e-${{ hashFiles('yarn.lock') }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,16 +29,16 @@ jobs:
         run: yarn --frozen-lockfile --cache-folder .yarn
 
       - name: Build runtime
-        run: yarn @dealmore/tf-next-runtime build
+        run: yarn workspace @dealmore/tf-next-runtime build
 
       - name: Build tf-next
         run: yarn workspace tf-next build
 
       - name: Build proxy
-        run: yarn @dealmore/terraform-next-proxy build
+        run: yarn workspace @dealmore/terraform-next-proxy build
 
       - name: Build deploy-trigger
-        run: yarn @dealmore/terraform-next-deploy-trigger build
+        run: yarn workspace @dealmore/terraform-next-deploy-trigger build
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -133,6 +133,8 @@ jobs:
         env:
           MINIO_ACCESS_KEY: test
           MINIO_SECRET_KEY: testtest
+        ports:
+          - 9000:9000
     env:
       SAM_CLI_TELEMETRY: 0
       # Don't worry these are fake AWS credentials for AWS SAM
@@ -140,7 +142,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: 4Xt3Rbx4DO21MhK1IHXZXRvVRDuqaQ0Wo5lILA/h
       MINIO_ACCESS_KEY: test
       MINIO_SECRET_KEY: testtest
-      S3_ENDPOINT: s3:9000
 
     steps:
       - name: Setup AWS SAM

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,17 +88,38 @@ jobs:
       # Don't worry these are fake AWS credentials for AWS SAM
       AWS_ACCESS_KEY_ID: ABIAZLJNBT8I3KFOU4NO
       AWS_SECRET_ACCESS_KEY: 4Xt3Rbx4DO21MhK1IHXZXRvVRDuqaQ0Wo5lILA/h
+
     steps:
       - name: Setup AWS SAM
         run: |
           brew tap aws/tap
           brew install aws-sam-cli
           sam --version
+
       - uses: actions/checkout@v2
-      - name: Download e2e fixtures
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            .yarn
+            **/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Download prebuilt e2e fixtures
         uses: actions/download-artifact@v2
         with:
           name: e2e-fixtures
-      - run: yarn install --frozen-lockfile --check-files
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --cache-folder .yarn
+
       - name: Run e2e-test
         run: yarn test:e2e --runInBand
+
+      - name: Output SAM logs
+        run: |
+          printf "\n\nOutput of sam-local.log:\n"
+          cat sam-local.log
+          printf "\n\nOutput of sam-api.log:\n"
+          cat sam-api.log

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ node_modules
 
 # Temp files
 *.swp*
+
+# Log files
+*.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,22 @@
 ##############
 # This docker-compose file is only meant for e2e testing packages that
 # require an S3 connection:
-# - deploy-trigger
+# - test/routes.test.ts
+# - packages/deploy-trigger
 ###############
 
 version: '3.6'
 
 services:
-  s3-emulator:
-    image: registry.gitlab.com/dealmore/dealmore-build-images:s3-emulator
+  local-s3:
+    image: minio/minio
     ports:
-      - '9000:9000'
+      - 9000:9000
+    command: server /data
     volumes:
-      - data-volume:/data
+      - s3-data:/data
     env_file:
       - ./test.env
 
 volumes:
-  data-volume:
+  s3-data:

--- a/package.json
+++ b/package.json
@@ -13,23 +13,20 @@
     "test:e2e": "jest test/routes.test.ts"
   },
   "devDependencies": {
-    "@dealmore/sammy": "^1.6.1",
+    "@dealmore/sammy": "^2.0.0",
     "@types/aws-lambda": "^8.10.76",
     "@types/hjson": "^2.4.2",
     "@types/jest": "^26.0.19",
     "@types/node": "^14.0.0",
-    "@types/unzipper": "^0.10.3",
     "aws-sdk": "*",
     "dotenv": "^8.2.0",
-    "etl": "^0.6.12",
     "fs-extra": "^9.1.0",
     "hjson": "^3.2.2",
     "jest": "^26.6.3",
     "prettier": "^2.0.5",
     "tmp": "^0.2.1",
     "ts-jest": "^26.5.5",
-    "typescript": "^4.4.2",
-    "unzipper": "^0.10.11"
+    "typescript": "^4.4.2"
   },
   "resolutions": {
     "archiver": "^5.3.0",

--- a/packages/deploy-trigger/src/__test__/deploy-trigger.test.ts
+++ b/packages/deploy-trigger/src/__test__/deploy-trigger.test.ts
@@ -1,8 +1,12 @@
 import * as fs from 'fs';
 import { S3 } from 'aws-sdk';
 
+import {
+  BucketHandler,
+  s3CreateBucket as createBucket,
+} from '../../../../test/utils';
 import { deployTrigger } from '../deploy-trigger';
-import { BucketHandler, createBucket, generateZipBundle } from './utils';
+import { generateZipBundle } from './utils';
 
 describe('deploy-trigger', () => {
   let s3: S3;

--- a/packages/deploy-trigger/src/__test__/get-or-create-manifest.test.ts
+++ b/packages/deploy-trigger/src/__test__/get-or-create-manifest.test.ts
@@ -1,14 +1,13 @@
 import { S3 } from 'aws-sdk';
 
+import {
+  BucketHandler,
+  s3CreateBucket as createBucket,
+} from '../../../../test/utils';
 import { deploymentConfigurationKey, manifestVersion } from '../constants';
 import { getOrCreateManifest } from '../get-or-create-manifest';
 import { Manifest } from '../types';
-
-import {
-  BucketHandler,
-  createBucket,
-  generateS3ClientForTesting,
-} from './utils';
+import { generateS3ClientForTesting } from './utils';
 
 describe('deploy-trigger', () => {
   let s3: S3;

--- a/packages/deploy-trigger/src/__test__/update-manifest.test.ts
+++ b/packages/deploy-trigger/src/__test__/update-manifest.test.ts
@@ -1,6 +1,10 @@
 import { S3 } from 'aws-sdk';
 
 import {
+  BucketHandler,
+  s3CreateBucket as createBucket,
+} from '../../../../test/utils';
+import {
   deploymentConfigurationKey,
   expireTagKey,
   expireTagValue,
@@ -9,12 +13,7 @@ import { getOrCreateManifest } from '../get-or-create-manifest';
 import { Manifest } from '../types';
 import { updateManifest } from '../update-manifest';
 import { generateRandomBuildId } from '../utils';
-import {
-  addFilesToS3Bucket,
-  BucketHandler,
-  createBucket,
-  generateS3ClientForTesting,
-} from './utils';
+import { addFilesToS3Bucket, generateS3ClientForTesting } from './utils';
 
 describe('deploy-trigger', () => {
   let s3: S3;

--- a/packages/deploy-trigger/src/__test__/utils.ts
+++ b/packages/deploy-trigger/src/__test__/utils.ts
@@ -4,62 +4,6 @@ import * as tmp from 'tmp';
 import * as fs from 'fs';
 import archiver from 'archiver';
 
-export interface BucketHandler {
-  bucketName: string;
-  destroy: () => Promise<boolean>;
-}
-
-/**
- * Helper to create a new bucket
- */
-export async function createBucket(
-  s3: S3,
-  bucketName: string = crypto.randomBytes(8).toString('hex')
-): Promise<BucketHandler> {
-  await s3
-    .createBucket({
-      Bucket: bucketName,
-    })
-    .promise();
-
-  return {
-    bucketName,
-    async destroy() {
-      // Empty bucket and destroy it
-      try {
-        // We can't delete a bucket before emptying its contents
-        const { Contents } = await s3
-          .listObjects({ Bucket: bucketName })
-          .promise();
-        if (Contents && Contents.length > 0) {
-          // TypeGuard
-          function isObjectIdentifier(
-            obj: S3.Object
-          ): obj is S3.ObjectIdentifier {
-            return typeof obj.Key === 'string';
-          }
-
-          await s3
-            .deleteObjects({
-              Bucket: bucketName,
-              Delete: {
-                Objects: Contents.filter(isObjectIdentifier).map(({ Key }) => ({
-                  Key,
-                })),
-              },
-            })
-            .promise();
-        }
-        await s3.deleteBucket({ Bucket: bucketName }).promise();
-        return true;
-      } catch (err) {
-        console.log(err);
-        return false;
-      }
-    },
-  };
-}
-
 export function generateS3ClientForTesting() {
   return new S3({
     endpoint: process.env.S3_ENDPOINT,

--- a/packages/deploy-trigger/src/handler.ts
+++ b/packages/deploy-trigger/src/handler.ts
@@ -138,7 +138,13 @@ export const handler = async function (event: S3Event | SQSEvent) {
 };
 
 async function s3Handler(Record: S3EventRecord) {
-  const s3 = new S3({ apiVersion: '2006-03-01' });
+  let s3: S3;
+  // Only for testing purposes when connecting against a local S3 backend
+  if (process.env.__DEBUG__USE_LOCAL_BUCKET) {
+    s3 = new S3(JSON.parse(process.env.__DEBUG__USE_LOCAL_BUCKET));
+  } else {
+    s3 = new S3({ apiVersion: '2006-03-01' });
+  }
   const deployBucket = process.env.TARGET_BUCKET;
   const distributionId = process.env.DISTRIBUTION_ID;
   const expireAfterDays: ExpireValue = parseExpireAfterDays();
@@ -175,12 +181,12 @@ async function s3Handler(Record: S3EventRecord) {
   });
 
   const [multiPaths, singlePaths] = prepareInvalidations(invalidationPaths);
-  await createCloudFrontInvalidation(
-    multiPaths,
-    singlePaths,
-    distributionId,
-    0
-  );
+  // await createCloudFrontInvalidation(
+  //   multiPaths,
+  //   singlePaths,
+  //   distributionId,
+  //   0
+  // );
 }
 
 async function sqsHandler(Record: SQSRecord) {

--- a/packages/deploy-trigger/src/handler.ts
+++ b/packages/deploy-trigger/src/handler.ts
@@ -180,13 +180,16 @@ async function s3Handler(Record: S3EventRecord) {
     manifest,
   });
 
-  const [multiPaths, singlePaths] = prepareInvalidations(invalidationPaths);
-  // await createCloudFrontInvalidation(
-  //   multiPaths,
-  //   singlePaths,
-  //   distributionId,
-  //   0
-  // );
+  // Allow skipping the creation of the invalidation for local e2e tests
+  if (!process.env.__DEBUG__SKIP_INVALIDATIONS) {
+    const [multiPaths, singlePaths] = prepareInvalidations(invalidationPaths);
+    await createCloudFrontInvalidation(
+      multiPaths,
+      singlePaths,
+      distributionId,
+      0
+    );
+  }
 }
 
 async function sqsHandler(Record: SQSRecord) {

--- a/test.env
+++ b/test.env
@@ -1,5 +1,2 @@
-# general settings
 MINIO_ACCESS_KEY=test
 MINIO_SECRET_KEY=testtest
-S3_ENDPOINT=localhost:9000
-

--- a/test/build-fixtures.js
+++ b/test/build-fixtures.js
@@ -4,14 +4,13 @@
 
 const { readdir, stat } = require('fs').promises;
 const path = require('path');
-const { spawn, spawnSync } = require('child_process');
+const { spawn } = require('child_process');
 const tmp = require('tmp');
 const fs = require('fs-extra');
 const { parse: parseJSON } = require('hjson');
 
 const DEBUG = false;
 const pathToFixtures = path.join(__dirname, 'fixtures');
-const yarnCommand = 'yarnpkg';
 
 // Get subdirs from a given path
 const getDirs = async (_path) => {
@@ -23,14 +22,6 @@ const getDirs = async (_path) => {
   }
   return dirs;
 };
-
-async function buildProxy(debug = false) {
-  const pathToProxy = path.join(__dirname, '../packages/proxy');
-  spawnSync(yarnCommand, ['build'], {
-    cwd: pathToProxy,
-    stdio: debug ? 'inherit' : 'ignore',
-  });
-}
 
 async function buildFixtures(debug = false) {
   const fixtures = (await getDirs(pathToFixtures)).map((_path) =>
@@ -101,7 +92,6 @@ async function buildFixtures(debug = false) {
 }
 
 async function main() {
-  await buildProxy(DEBUG);
   await buildFixtures(DEBUG);
 }
 

--- a/test/declarations.d.ts
+++ b/test/declarations.d.ts
@@ -1,1 +1,0 @@
-declare module 'etl';

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -6,26 +6,33 @@ import { parse as parseJSON } from 'hjson';
 import { ConfigOutput } from 'tf-next/src/types';
 import { CloudFrontResultResponse, S3Event } from 'aws-lambda';
 import {
-  generateSAM,
-  LambdaSAM,
+  generateLocalSAM,
+  LocalSAMGenerator,
+  generateAPISAM,
+  APISAMGenerator,
   generateProxySAM,
   ProxySAM,
   normalizeCloudFrontHeaders,
   ConfigLambda,
 } from '@dealmore/sammy';
-import unzipper, { Entry } from 'unzipper';
-import etl from 'etl';
 import S3 from 'aws-sdk/clients/s3';
 
 import {
   s3CreateBucket,
   BucketHandler,
   getLocalIpAddressFromHost,
+  AttachLoggerResult,
+  attachLogger,
 } from './utils';
 
 // We use an increased timeout here because in the worst case
 // AWS SAM needs to download a docker image before the test can run
-const TEST_TIMEOUT = 2 * 60 * 1000;
+jest.setTimeout(2 * 60 * 1000);
+
+// Log files where the output from the SAM CLI should be written to
+// (Using console.log for this would )
+const SAMLogFileLocal = 'sam-local.log';
+const SAMLogFileAPI = 'sam-api.log';
 
 const pathToFixtures = path.join(__dirname, 'fixtures');
 const pathToProxyPackage = require.resolve(
@@ -41,7 +48,6 @@ const pathToDeployTriggerPackage = require.resolve(
   }
 );
 
-const deployTriggerFunctionKey = '__deploy-trigger';
 const s3Endpoint = process.env.S3_ENDPOINT
   ? process.env.S3_ENDPOINT
   : `${getLocalIpAddressFromHost()}:9000`;
@@ -73,21 +79,44 @@ describe('Test proxy config', () => {
     });
   });
 
-  for (const fixture of fs
-    .readdirSync(pathToFixtures)
-    .filter((fixture) => fixture.startsWith('00'))) {
+  for (const fixture of fs.readdirSync(pathToFixtures)) {
     describe(`Testing fixture: ${fixture}`, () => {
       const pathToFixture = path.join(pathToFixtures, fixture);
       let config: ConfigOutput;
       let probeFile: ProbeFile;
-      let lambdaSAM: LambdaSAM;
+      /**
+       * Logger for apiSAM
+       */
+      let loggerApiSAM: AttachLoggerResult;
+      /**
+       * apiSAM handles request against SSR Lambdas from Next.js
+       * (through API-Gateway)
+       */
+      let apiSAM: APISAMGenerator;
+      /**
+       * Logger for localSAM
+       */
+      let loggerlocalSAM: AttachLoggerResult;
+      /**
+       * lambdaSAM handles request against deploy trigger component
+       */
+      let localSAM: LocalSAMGenerator;
+      /**
+       * proxySAM handles requests against the proxy (Lambda@Edge)
+       */
       let proxySAM: ProxySAM;
+      /**
+       * Bucket where the static-files.zip file is uploaded to
+       * (for further processing through deploy trigger)
+       */
       let deployBucket: BucketHandler;
+      /**
+       * Target bucket where the static files are extracted to
+       * (from deploy trigger)
+       */
       let staticFilesBucket: BucketHandler;
 
       beforeAll(async () => {
-        staticFilesBucket = await s3CreateBucket(s3);
-
         // Get the config
         config = require(path.join(
           pathToFixture,
@@ -101,76 +130,44 @@ describe('Test proxy config', () => {
             .toString('utf-8')
         ) as ProbeFile;
 
-        // Generate SAM for SSR (Lambda)
-        const lambdas: Record<string, ConfigLambda> = {};
-        for (const [key, lambda] of Object.entries(config.lambdas)) {
-          lambdas[key] = {
-            ...lambda,
-            route: undefined,
-            routes: {
-              ApiRoot: `${lambda.route}/`,
-              Api: `${lambda.route}/{proxy+}`,
+        /* ---------------------------------------------------------------------
+         * Prepare deploy-trigger integration
+         * -------------------------------------------------------------------*/
+        const staticDeployFunctionName = 'deployTrigger';
+
+        staticFilesBucket = await s3CreateBucket(s3);
+        deployBucket = await s3CreateBucket(s3);
+
+        localSAM = await generateLocalSAM({
+          lambdas: {
+            [staticDeployFunctionName]: {
+              handler: 'handler.handler',
+              runtime: 'nodejs14.x',
+              filename: pathToDeployTriggerPackage,
+              environment: {
+                TARGET_BUCKET: staticFilesBucket.bucketName,
+                // Disable object expiration - no CF invalidation is created
+                EXPIRE_AFTER_DAYS: '0',
+                __DEBUG__USE_LOCAL_BUCKET: JSON.stringify({
+                  endpoint: s3Endpoint,
+                  accessKeyId: process.env.MINIO_ACCESS_KEY,
+                  secretAccessKey: process.env.MINIO_SECRET_KEY,
+
+                  s3ForcePathStyle: true,
+                  signatureVersion: 'v4',
+                  sslEnabled: false,
+                }),
+              },
             },
-            memorySize: 1024,
-          };
-        }
-
-        // Generate SAM for deploy trigger
-        lambdas[deployTriggerFunctionKey] = {
-          handler: 'handler.handler',
-          runtime: 'nodejs14.x',
-          filename: pathToDeployTriggerPackage,
-          environment: {
-            TARGET_BUCKET: staticFilesBucket.bucketName,
-            EXPIRE_AFTER_DAYS: '0', // Disable object expiration
-            __DEBUG__USE_LOCAL_BUCKET: JSON.stringify({
-              endpoint: s3Endpoint,
-              accessKeyId: process.env.MINIO_ACCESS_KEY,
-              secretAccessKey: process.env.MINIO_SECRET_KEY,
-
-              s3ForcePathStyle: true,
-              signatureVersion: 'v4',
-              sslEnabled: false,
-            }),
           },
-        };
-
-        lambdaSAM = await generateSAM({
-          lambdas,
           cwd: path.join(pathToFixture, '.next-tf'),
-          onData(data:string) {
-            console.log(data.toString());
-          },
-          onError(data:string) {
-            console.log(data.toString());
-          },
+          randomizeFunctionNames: false,
         });
-        await lambdaSAM.start();
-
-        // Generate SAM for Proxy (Lambda@Edge)
-        const proxyConfig = {
-          routes: config.routes,
-          staticRoutes: config.staticRoutes,
-          lambdaRoutes: Object.values(config.lambdas).map(
-            (lambda) => lambda.route
-          ),
-          prerenders: config.prerenders,
-        };
-
-        proxySAM = await generateProxySAM({
-          pathToProxyPackage,
-          proxyConfig: JSON.stringify(proxyConfig),
-          onData(data) {
-            console.log(data.toString());
-          },
-          onError(data) {
-            console.log(data.toString());
-          },
-        });
-        await proxySAM.start();
+        // Attach logger
+        loggerlocalSAM = attachLogger(SAMLogFileLocal, localSAM);
+        await localSAM.start();
 
         // Upload static files and process it though static-deploy Lambda
-        deployBucket = await s3CreateBucket(s3);
         const staticDeploymentObject = await s3
           .upload({
             Key: 'static-website-files.zip',
@@ -181,13 +178,7 @@ describe('Test proxy config', () => {
           })
           .promise();
 
-        const staticDeployFunctionName = lambdaSAM.mapping.get(
-          deployTriggerFunctionKey
-        )!;
-
-        console.log('staticDeployFunctionName', staticDeployFunctionName)
-
-        await lambdaSAM.sendEvent(
+        await localSAM.sendEvent(
           staticDeployFunctionName,
           'RequestResponse',
           JSON.stringify({
@@ -205,151 +196,186 @@ describe('Test proxy config', () => {
             ],
           } as S3Event)
         );
-      }, TEST_TIMEOUT);
+
+        /* ---------------------------------------------------------------------
+         * Prepare API-Gateway integration
+         * -------------------------------------------------------------------*/
+
+        // Generate the Lambdas for API-Gateway integration (SSR)
+        const lambdas: Record<string, ConfigLambda> = {};
+        for (const [key, lambda] of Object.entries(config.lambdas)) {
+          lambdas[key] = {
+            ...lambda,
+            route: undefined,
+            routes: {
+              ApiRoot: `${lambda.route}/`,
+              Api: `${lambda.route}/{proxy+}`,
+            },
+            memorySize: 1024,
+          };
+        }
+
+        apiSAM = await generateAPISAM({
+          lambdas,
+          cwd: path.join(pathToFixture, '.next-tf'),
+          randomizeFunctionNames: true,
+        });
+        // Attach logger
+        loggerApiSAM = attachLogger(SAMLogFileAPI, apiSAM);
+        await apiSAM.start();
+
+        /* ---------------------------------------------------------------------
+         * Prepare Proxy integration (Lambda@Edge)
+         * -------------------------------------------------------------------*/
+
+        const proxyConfig = {
+          routes: config.routes,
+          staticRoutes: config.staticRoutes,
+          lambdaRoutes: Object.values(config.lambdas).map(
+            (lambda) => lambda.route
+          ),
+          prerenders: config.prerenders,
+        };
+
+        proxySAM = await generateProxySAM({
+          pathToProxyPackage,
+          proxyConfig: JSON.stringify(proxyConfig),
+          onData(data: string) {
+            console.log(data.toString());
+          },
+          onError(data: string) {
+            console.log(data.toString());
+          },
+        });
+        await proxySAM.start();
+      });
 
       afterAll(async () => {
+        // Close loggers
+        loggerlocalSAM.stop();
+        loggerApiSAM.stop();
+
         // Shutdown SAM
-        await lambdaSAM.stop();
+        await localSAM.stop();
+        await apiSAM.stop();
         await proxySAM.stop();
 
         // Cleanup buckets
-        // await deployBucket.destroy();
-        // await staticFilesBucket.destroy();
-      }, TEST_TIMEOUT);
+        await deployBucket.destroy();
+        await staticFilesBucket.destroy();
+      });
 
-      test(
-        'Proxy',
-        async () => {
-          for (const probe of probeFile.probes) {
-            const Request = await proxySAM.sendRequestEvent({
-              uri: probe.path,
-            });
+      test('Proxy', async () => {
+        for (const probe of probeFile.probes) {
+          const Request = await proxySAM.sendRequestEvent({
+            uri: probe.path,
+          });
 
-            if ('origin' in Request) {
-              // Request
-              if (Request.origin?.custom) {
-                if (Request.origin.custom.domainName === 'local-apigw.local') {
-                  // Request should be served by lambda (SSR)
-                  const basePath = Request.origin.custom.path;
-                  const { uri, querystring } = Request;
+          if ('origin' in Request) {
+            // Request
+            if (Request.origin?.custom) {
+              if (Request.origin.custom.domainName === 'local-apigw.local') {
+                // Request should be served by lambda (SSR)
+                const basePath = Request.origin.custom.path;
+                const { uri, querystring } = Request;
 
-                  // Merge request headers and custom headers from origin
-                  const headers = {
-                    ...normalizeCloudFrontHeaders(Request.headers),
-                    ...normalizeCloudFrontHeaders(
-                      Request.origin.custom.customHeaders
-                    ),
-                  };
-                  const requestPath = `${basePath}${uri}${
-                    querystring !== '' ? `?${querystring}` : ''
-                  }`;
+                // Merge request headers and custom headers from origin
+                const headers = {
+                  ...normalizeCloudFrontHeaders(Request.headers),
+                  ...normalizeCloudFrontHeaders(
+                    Request.origin.custom.customHeaders
+                  ),
+                };
+                const requestPath = `${basePath}${uri}${
+                  querystring !== '' ? `?${querystring}` : ''
+                }`;
 
-                  const lambdaResponse = await lambdaSAM
-                    .sendApiGwRequest(requestPath, {
-                      headers,
-                    })
-                    .then((res) => {
-                      return res.text();
-                    });
+                const lambdaResponse = await apiSAM
+                  .sendApiGwRequest(requestPath, {
+                    headers,
+                  })
+                  .then((res) => {
+                    return res.text();
+                  });
 
-                  if (probe.mustContain) {
-                    expect(lambdaResponse).toContain(probe.mustContain);
-                  }
-                } else {
-                  // Request is an external rewrite
-                  if (probe.destPath) {
-                    const { custom: customOrigin } = Request.origin;
-                    const originRequest = new URL(
-                      `${customOrigin.protocol}://${customOrigin.domainName}${
-                        Request.uri
-                      }${Request.querystring ? `?${Request.querystring}` : ''}`
-                    );
-
-                    // Check for custom ports
-                    if (customOrigin.port !== 80 && customOrigin.port !== 443) {
-                      originRequest.port = customOrigin.port.toString();
-                    }
-
-                    expect(originRequest).toEqual(new URL(probe.destPath));
-                  }
-                }
-              } else if (Request.origin?.s3) {
-                // Request should be served by static file system (S3)
-                // Check static routes
-                const { uri } = Request;
-                if (config.staticRoutes.find((route) => route === uri)) {
-                  const pathToStaticFilesArchive = path.join(
-                    pathToFixture,
-                    '.next-tf',
-                    config.staticFilesArchive
-                  );
-
-                  const fileContent = await new Promise<Buffer>(
-                    (resolve, reject) => {
-                      let found = false;
-                      // Remove leading / from the path
-                      const filePath = uri.replace(/^\//, '');
-
-                      fs.createReadStream(pathToStaticFilesArchive)
-                        .pipe(unzipper.Parse())
-                        .pipe(
-                          etl.map(async (entry: Entry) => {
-                            if (entry.path === filePath) {
-                              const content = await entry.buffer();
-                              found = true;
-                              resolve(content);
-                            } else {
-                              entry.autodrain();
-                            }
-                          })
-                        )
-                        .on('finish', () => {
-                          if (!found) {
-                            reject(`Could not find static file ${filePath}`);
-                          }
-                        });
-                    }
-                  ).then((buffer) => buffer.toString('utf-8'));
-
-                  if (probe.mustContain) {
-                    expect(fileContent).toContain(probe.mustContain);
-                  }
-                } else {
-                  fail(
-                    `Could not resolve ${probe.path} to an existing lambda! (Resolved to: ${uri})`
-                  );
+                if (probe.mustContain) {
+                  expect(lambdaResponse).toContain(probe.mustContain);
                 }
               } else {
-                fail(`Path ${probe.path} returned invalid proxy request`);
+                // Request is an external rewrite
+                if (probe.destPath) {
+                  const { custom: customOrigin } = Request.origin;
+                  const originRequest = new URL(
+                    `${customOrigin.protocol}://${customOrigin.domainName}${
+                      Request.uri
+                    }${Request.querystring ? `?${Request.querystring}` : ''}`
+                  );
+
+                  // Check for custom ports
+                  if (customOrigin.port !== 80 && customOrigin.port !== 443) {
+                    originRequest.port = customOrigin.port.toString();
+                  }
+
+                  expect(originRequest).toEqual(new URL(probe.destPath));
+                }
+              }
+            } else if (Request.origin?.s3) {
+              // Request should be served by static file system (S3)
+              // Check static routes
+              const { uri } = Request;
+              if (config.staticRoutes.find((route) => route === uri)) {
+                const filePath = uri.replace(/^\//, '');
+
+                // Download the file from the S3
+                const fileContent = await s3
+                  .getObject({
+                    Bucket: staticFilesBucket.bucketName,
+                    Key: filePath,
+                  })
+                  .promise()
+                  .then(({ Body }) => {
+                    if (Body) {
+                      return Body.toString();
+                    }
+
+                    throw new Error(`File is empty: ${filePath}`);
+                  });
+
+                if (probe.mustContain) {
+                  expect(fileContent).toContain(probe.mustContain);
+                }
+              } else {
+                fail(
+                  `Could not resolve ${probe.path} to an existing lambda! (Resolved to: ${uri})`
+                );
               }
             } else {
-              // Request-Response
-              const Response = Request as CloudFrontResultResponse;
+              fail(`Path ${probe.path} returned invalid proxy request`);
+            }
+          } else {
+            // Request-Response
+            const Response = Request as CloudFrontResultResponse;
 
-              if (probe.status) {
-                expect(Response.status).toBe(probe.status.toString());
-              }
+            if (probe.status) {
+              expect(Response.status).toBe(probe.status.toString());
+            }
 
-              for (const header in probe.responseHeaders) {
-                const lowerHeader = header.toLowerCase();
-                expect(Response.headers![lowerHeader]).toBeDefined();
-                expect(Response.headers![lowerHeader]).toContainEqual(
-                  expect.objectContaining({
-                    value: probe.responseHeaders[header],
-                  })
-                );
-              }
+            for (const header in probe.responseHeaders) {
+              const lowerHeader = header.toLowerCase();
+              expect(Response.headers![lowerHeader]).toBeDefined();
+              expect(Response.headers![lowerHeader]).toContainEqual(
+                expect.objectContaining({
+                  value: probe.responseHeaders[header],
+                })
+              );
+            }
 
-              if (probe.statusDescription) {
-                expect(Response.statusDescription).toBe(
-                  probe.statusDescription
-                );
-              }
+            if (probe.statusDescription) {
+              expect(Response.statusDescription).toBe(probe.statusDescription);
             }
           }
-        },
-        TEST_TIMEOUT
-      );
+        }
+      });
     });
   }
 });

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -48,9 +48,7 @@ const pathToDeployTriggerPackage = require.resolve(
   }
 );
 
-const s3Endpoint = process.env.S3_ENDPOINT
-  ? process.env.S3_ENDPOINT
-  : `${getLocalIpAddressFromHost()}:9000`;
+const s3Endpoint = `${getLocalIpAddressFromHost()}:9000`;
 
 interface ProbeFile {
   probes: {

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -144,8 +144,9 @@ describe('Test proxy config', () => {
               filename: pathToDeployTriggerPackage,
               environment: {
                 TARGET_BUCKET: staticFilesBucket.bucketName,
-                // Disable object expiration - no CF invalidation is created
                 EXPIRE_AFTER_DAYS: '0',
+                // No CF invalidation is created
+                __DEBUG__SKIP_INVALIDATIONS: 'true',
                 __DEBUG__USE_LOCAL_BUCKET: JSON.stringify({
                   endpoint: s3Endpoint,
                   accessKeyId: process.env.MINIO_ACCESS_KEY,

--- a/test/utils/attach-logger.ts
+++ b/test/utils/attach-logger.ts
@@ -1,0 +1,48 @@
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+
+type AttachLoggerResult = {
+  /**
+   * Detaches the logger from the emitter and closes the write stream to the
+   * log file
+   */
+  stop(): void;
+};
+
+/**
+ * Attaches a logger to an emitter and puts the logs into a file
+ *
+ * @param filePath - Path of the file where the logs should be put in
+ * @param emitter - Emitter from where the logs should taken, supports `data` and `error` events
+ */
+function attachLogger<Emitter extends EventEmitter>(
+  filePath: string,
+  emitter: Emitter
+): AttachLoggerResult {
+  const writeStream = fs.createWriteStream(filePath, {
+    // Open file for appending. The file is created if it does not exist.
+    flags: 'a',
+  });
+  function onData(data: string) {
+    writeStream.write(data.toString());
+  }
+  function onError(data: string) {
+    writeStream.write(data.toString());
+  }
+
+  emitter.on('data', onData);
+  emitter.on('error', onError);
+
+  return {
+    stop() {
+      emitter.off('data', onData);
+      emitter.off('error', onError);
+
+      // Close stream to the log file
+      writeStream.close();
+    },
+  };
+}
+
+export { attachLogger };
+export type { AttachLoggerResult };

--- a/test/utils/host-ip-address.ts
+++ b/test/utils/host-ip-address.ts
@@ -16,7 +16,7 @@ function getLocalIpAddressFromHost() {
           results[name] = [];
         }
 
-        results[name].push(net.address);
+        results[name]!.push(net.address);
       }
     }
   }

--- a/test/utils/host-ip-address.ts
+++ b/test/utils/host-ip-address.ts
@@ -1,0 +1,32 @@
+import { networkInterfaces } from 'os';
+
+/**
+ * Utility to find the local ip address
+ * @see: https://stackoverflow.com/a/8440736/831465
+ */
+function getLocalIpAddressFromHost() {
+  const nets = networkInterfaces();
+  const results: Record<string, Array<string>> = {}; // or just '{}', an empty object
+
+  for (const name of Object.keys(nets)) {
+    for (const net of nets[name]!) {
+      // skip over non-ipv4 and internal (i.e. 127.0.0.1) addresses
+      if (net.family === 'IPv4' && !net.internal) {
+        if (!results[name]) {
+          results[name] = [];
+        }
+
+        results[name].push(net.address);
+      }
+    }
+  }
+
+  // Get the first address we find
+  for (const [, addresses] of Object.entries(results)) {
+    for (const address of addresses) {
+      return address;
+    }
+  }
+}
+
+export { getLocalIpAddressFromHost };

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,6 +1,5 @@
-// Types
-export type { BucketHandler } from './s3-create-bucket';
-
-// Value exports
+export { attachLogger } from './attach-logger';
+export type { AttachLoggerResult } from './attach-logger';
 export { getLocalIpAddressFromHost } from './host-ip-address';
 export { s3CreateBucket } from './s3-create-bucket';
+export type { BucketHandler } from './s3-create-bucket';

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,0 +1,6 @@
+// Types
+export type { BucketHandler } from './s3-create-bucket';
+
+// Value exports
+export { getLocalIpAddressFromHost } from './host-ip-address';
+export { s3CreateBucket } from './s3-create-bucket';

--- a/test/utils/s3-create-bucket.ts
+++ b/test/utils/s3-create-bucket.ts
@@ -1,0 +1,62 @@
+import { randomBytes } from 'crypto';
+
+import S3 from 'aws-sdk/clients/s3';
+
+interface BucketHandler {
+  bucketName: string;
+  destroy: () => Promise<boolean>;
+}
+
+/**
+ * Helper to create a new bucket
+ */
+async function s3CreateBucket(
+  s3: S3,
+  bucketName: string = randomBytes(8).toString('hex')
+): Promise<BucketHandler> {
+  await s3
+    .createBucket({
+      Bucket: bucketName,
+    })
+    .promise();
+
+  return {
+    bucketName,
+    async destroy() {
+      // Empty bucket and destroy it
+      try {
+        // We can't delete a bucket before emptying its contents
+        const { Contents } = await s3
+          .listObjects({ Bucket: bucketName })
+          .promise();
+        if (Contents && Contents.length > 0) {
+          // TypeGuard
+          function isObjectIdentifier(
+            obj: S3.Object
+          ): obj is S3.ObjectIdentifier {
+            return typeof obj.Key === 'string';
+          }
+
+          await s3
+            .deleteObjects({
+              Bucket: bucketName,
+              Delete: {
+                Objects: Contents.filter(isObjectIdentifier).map(({ Key }) => ({
+                  Key,
+                })),
+              },
+            })
+            .promise();
+        }
+        await s3.deleteBucket({ Bucket: bucketName }).promise();
+        return true;
+      } catch (err) {
+        console.log(err);
+        return false;
+      }
+    },
+  };
+}
+
+export type { BucketHandler };
+export { s3CreateBucket };

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,10 +401,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@dealmore/sammy@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@dealmore/sammy/-/sammy-1.6.1.tgz#b5340a838b6220bde3d3a137d57c7a82ddedf365"
-  integrity sha512-KPt+yIt/A9IJ/TT41GvI5D2v2IOlK+hZElB20a5dnQX0F43vvNp8fg4rPJEh4ZrtOyYB2g1+cO5ontdd+0lkIg==
+"@dealmore/sammy@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@dealmore/sammy/-/sammy-2.0.0.tgz#dce836799f6991cd92cd763caaba6a4787bd0750"
+  integrity sha512-rTLCOWKXS74H0jC4RBNQfiqb6vgo4beGwYwus0uxyEAQhMCrZpC9CpuzDecY+Jd1+oKMkI7+1gdupN1wAIwHUw==
   dependencies:
     aws-sdk "^2.804.0"
     change-case "^4.1.2"
@@ -1512,16 +1512,6 @@ bluebird@~3.4.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
   integrity sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=
 
-bluebird@~3.5.0:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
-  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
-
-bluebird@~3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
@@ -2150,17 +2140,6 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
   integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==
 
-csv-parser@~1.8.0:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/csv-parser/-/csv-parser-1.8.1.tgz#a0692fd988157d6a383edaa325f3019e533c5f16"
-  integrity sha1-oGkv2YgVfWo4PtqjJfMBnlM8XxY=
-  dependencies:
-    generate-function "^1.0.1"
-    generate-object-property "^1.0.0"
-    inherits "^2.0.1"
-    minimist "^0.2.0"
-    ndjson "^1.4.0"
-
 cuid@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.8.tgz#cbb88f954171e0d5747606c0139fb65c5101eac0"
@@ -2505,17 +2484,6 @@ etag@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
-
-etl@^0.6.12:
-  version "0.6.12"
-  resolved "https://registry.yarnpkg.com/etl/-/etl-0.6.12.tgz#c13d5849289935bbe7030c10c6415c18359b45f0"
-  integrity sha512-OJSq36CVoKTLp4/vPSaPI6KhBoIghBngpB/9qAm03t6hsJ2z5aN5kZEGtMfQpXgYXvE6wn0VQJKEFftiK3v5Rg==
-  dependencies:
-    bluebird "~3.5.0"
-    csv-parser "~1.8.0"
-    duplexer2 "~0.1.4"
-    moment "~2.21.0"
-    streamz "~1.8.10"
 
 event-target-shim@^5.0.0:
   version "5.0.1"
@@ -2867,18 +2835,6 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
-
-generate-function@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-1.1.0.tgz#54c21b080192b16d9877779c5bb81666e772365f"
-  integrity sha1-VMIbCAGSsW2Yd3ecW7gWZudyNl8=
-
-generate-object-property@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  integrity sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
-  dependencies:
-    is-property "^1.0.0"
 
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
@@ -3440,11 +3396,6 @@ is-potential-custom-element-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
-
-is-property@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
-  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
 is-regex@^1.1.3:
   version "1.1.3"
@@ -4040,7 +3991,7 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -4344,11 +4295,6 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
-  integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
-
 minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -4388,11 +4334,6 @@ mkdirp@1.x, mkdirp@^1.0.4:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-moment@~2.21.0:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
-  integrity sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==
 
 ms@2.0.0:
   version "2.0.0"
@@ -4447,16 +4388,6 @@ ncc-zip@^1.0.0:
     arg "^5.0.0"
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
-
-ndjson@^1.4.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/ndjson/-/ndjson-1.5.0.tgz#ae603b36b134bcec347b452422b0bf98d5832ec8"
-  integrity sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=
-  dependencies:
-    json-stringify-safe "^5.0.1"
-    minimist "^1.2.0"
-    split2 "^2.1.0"
-    through2 "^2.0.3"
 
 needle@^2.2.1:
   version "2.6.0"
@@ -5721,13 +5652,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split2@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
-  integrity sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
-  dependencies:
-    through2 "^2.0.2"
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -5830,13 +5754,6 @@ stream-parser@^0.3.1:
   integrity sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=
   dependencies:
     debug "2"
-
-streamz@~1.8.10:
-  version "1.8.12"
-  resolved "https://registry.yarnpkg.com/streamz/-/streamz-1.8.12.tgz#e022bf773fb0093de81f3cd2105390bbc9231613"
-  integrity sha512-O75iqd6oo3tqlfCKoReXLwLAweyr0dkzSPxDLPkmHtbPz8Y/+s2sSOAJHpDYzw2LGZbWBbHgd1Df4zw3i7bqiw==
-  dependencies:
-    bluebird "~3.7.2"
 
 string-hash@1.1.3:
   version "1.1.3"
@@ -6058,14 +5975,6 @@ throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
-
-through2@^2.0.2, through2@^2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
-  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
-  dependencies:
-    readable-stream "~2.3.6"
-    xtend "~4.0.1"
 
 timers-browserify@2.0.12, timers-browserify@^2.0.4:
   version "2.0.12"
@@ -6664,7 +6573,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
The current e2e implementation does not cover the upload & extraction of the static files via the static-deploy package.
This PR changes that:

- Uploads the static-files.zip to an S3 bucket
- Unpack the static files zip via the `static-deploy` lambda
- Downloads static files from S3 if requested by the Proxy