### PR TITLE
Multiple deployments: handle static assets

### DIFF
--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -91,8 +91,8 @@ resource "aws_s3_bucket_policy" "origin_access" {
 # Lambda
 ########
 
-# TODO: Look into if it would be more sense to combine all policies here into
-# a single ressorce
+# TODO: Look into if it would make more sense to combine all policies here into
+# a single resource
 
 #
 # Lambda permissions for updating the static files bucket and to create

--- a/packages/tf-next/src/types.ts
+++ b/packages/tf-next/src/types.ts
@@ -2,6 +2,7 @@ import { Route } from '@vercel/routing-utils';
 
 export interface ConfigOutput {
   buildId: string;
+  deploymentId?: string;
   routes: Route[];
   staticRoutes: string[];
   staticFilesArchive: string;


### PR DESCRIPTION
This is the second PR in a series to introduce the handling of multiple parallel deployments.

What this PR does:

* Introduce a deployment id when building
* Upload static assets based on the deployment id
* Route to the correct location in the proxy based on deployment id

Things left to do:

* Handle image(s) (optimization)
* Handle VPCs
* Allow for things like tags, role boundaries, etc. to be passed on to the create-deployment command
* Remove code duplication (TF/TS)
* Build domain alias switching to allow pointing a (sub)domain to a specific deployment (rollback of production deployments)
* Documentation/an example of how to setup wildcard subdomains for this
* New architecture picture
